### PR TITLE
Task 8 Overwrite delete view for django admin Indicator and Dataset admin

### DIFF
--- a/wazimap_ng/datasets/admin.py
+++ b/wazimap_ng/datasets/admin.py
@@ -12,7 +12,7 @@ from django.db.models import Q, CharField
 from django.db.models.functions import Cast
 from django.template.response import TemplateResponse
 from django.contrib.admin.utils import model_ngettext, unquote
-
+from django.core.exceptions import PermissionDenied
 
 from django_q.tasks import async_task
 

--- a/wazimap_ng/datasets/tasks.py
+++ b/wazimap_ng/datasets/tasks.py
@@ -8,6 +8,7 @@ from django.db.models import Sum, FloatField
 from django.db.models.functions import Cast
 from django.contrib.postgres.fields.jsonb import KeyTextTransform
 from django.db.models import Count
+from django.db.models.query import QuerySet
 
 from . import models
 from .dataloader import loaddata
@@ -114,4 +115,19 @@ def indicator_data_extraction(indicator, **kwargs):
         "model": "indicator",
         "name": indicator.name,
         "id": indicator.id,
+    }
+
+@transaction.atomic
+def delete_data(data, object_name, **kwargs):
+    """
+    Delete data
+    """
+    data.delete()
+
+    is_queryset = isinstance(data, QuerySet)
+
+    return {
+        "is_queryset": is_queryset,
+        "data": data,
+        "object_name": object_name,
     }

--- a/wazimap_ng/datasets/templates/admin/datasets_delete_confirmation.html
+++ b/wazimap_ng/datasets/templates/admin/datasets_delete_confirmation.html
@@ -1,0 +1,28 @@
+{% extends "admin/delete_confirmation.html" %}
+
+
+{% block content %}
+    <p>Are you sure you want to delete the {{ object_name }} ? All of the following related items will be deleted:</p>
+    
+    <h2>Summary</h2>
+	<ul>
+	    <li>{{ object_name|capfirst }}: {{ obj.name }}</li>
+	</ul>
+
+	<h2>Related Objects</h2>
+	<ul>
+		{% for field in related_fileds %}
+	    	<li>{{ field.name|capfirst }}: {{ field.count }}</li>
+		{% endfor %}
+	</ul>
+    
+    <form method="post">{% csrf_token %}
+    <div>
+    <input type="hidden" name="post" value="yes">
+    {% if is_popup %}<input type="hidden" name="{{ is_popup_var }}" value="1">{% endif %}
+    {% if to_field %}<input type="hidden" name="{{ to_field_var }}" value="{{ to_field }}">{% endif %}
+    <input type="submit" value="Yes, I’m sure">
+    <a href="#" class="button cancel-link">No, take me back</a>
+    </div>
+    </form>
+{% endblock %}

--- a/wazimap_ng/datasets/templates/admin/datasets_delete_selected_confirmation.html
+++ b/wazimap_ng/datasets/templates/admin/datasets_delete_selected_confirmation.html
@@ -1,0 +1,31 @@
+{% extends "admin/delete_selected_confirmation.html" %}
+{% load i18n l10n admin_urls static %}
+
+{% block content %}
+    <p>Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted:</p>
+    
+    <h2>Summary</h2>
+    <ul>
+        <li>{{ objects_name}} : {{ queryset.count }}</li>
+    </ul>
+    
+    <h2>Objects</h2>
+        <ul>
+            {% for obj in queryset %}
+                <li>{{ obj.name}}</li>
+            {% endfor %}
+        </ul>
+    
+    <form method="post">{% csrf_token %}
+    <div>
+    {% for obj in queryset %}
+        <input type="hidden" name="{{ action_checkbox_name }}" value="{{ obj.pk|unlocalize }}">
+    {% endfor %}
+    <input type="hidden" name="action" value="delete_selected_data">
+    <input type="hidden" name="post" value="yes">
+    <input type="submit" value="Yes, I’m sure">
+    <a href="#" class="button cancel-link">No, take me back</a>
+    </div>
+    </form>
+
+{% endblock %}


### PR DESCRIPTION
* Change view template and excluded related data
* Base admin model class to make changes dynamic
* Added custom action for delete_selected
* Run delete task in background
* Show notification and info messages before and after deleting data

@adieyal Please review

Our delete pages were taking time because they were loading related data.
I have overwritten delete view as this is the only way we had control over related data fetch.

Right now i am showing count related data that will be deleted with object, We can remove this too if page is still slow. 
It worked fine for me and I tested for around 2M+
