### PR TITLE
Fixed breaking universe query in case of missing groups for dataset

### DIFF
--- a/wazimap_ng/datasets/admin.py
+++ b/wazimap_ng/datasets/admin.py
@@ -283,12 +283,15 @@ class IndicatorAdminForm(forms.ModelForm):
                 self.fields['groups'].initial = self.instance.groups
 
             if "universe" in self.fields:
-                condition = reduce(
-                    operator.or_, [Q(as_string__icontains=group) for group in self.instance.dataset.groups]
-                )
-                self.fields['universe'].queryset = models.Universe.objects.annotate(
-                    as_string=Cast('filters', CharField())
-                ).filter(condition)
+                if not self.instance.dataset.groups:
+                    self.fields['universe'].queryset = models.Universe.objects.none()
+                else:
+                    condition = reduce(
+                        operator.or_, [Q(as_string__icontains=group) for group in self.instance.dataset.groups]
+                    )
+                    self.fields['universe'].queryset = models.Universe.objects.annotate(
+                        as_string=Cast('filters', CharField())
+                    ).filter(condition)
 
 @admin.register(models.Indicator)
 class IndicatorAdmin(BaseAdminModel):


### PR DESCRIPTION
@adieyal Please review
Got issue while i was testing for a bug.

Issue: 
Universe query in admin panel for Indicator admin was throwing error if groups does not exits.
Solution:
Send `Universe.objects.none` In case where dataset doesn't have any groups

Traceback:

<img width="1601" alt="Screenshot 2020-02-25 at 5 26 00 PM" src="https://user-images.githubusercontent.com/6871866/75245547-f1958980-57f3-11ea-88a2-c43ba6f1b525.png">
