### PR TITLE
Increase retry time of Django Q so dataset queries are not duplicated

### DIFF
--- a/wazimap_ng/config/common.py
+++ b/wazimap_ng/config/common.py
@@ -227,6 +227,11 @@ class Common(Configuration):
 
     CORS_ORIGIN_ALLOW_ALL = True
 
+    Q_CLUSTER = {
+       "orm": 'default',
+       "retry": 10000,
+    }
+
 FILE_SIZE_LIMIT = 1000 * 1024 * 1024
 ALLOWED_FILE_EXTENSIONS = ["csv", "xls", "xlsx"]
 

--- a/wazimap_ng/config/local.py
+++ b/wazimap_ng/config/local.py
@@ -41,7 +41,3 @@ class Local(Common):
     }
 
     FILE_SIZE_LIMIT = 1000 * 1024 * 1024
-    Q_CLUSTER = {
-       "orm": 'default',
-       "retry": 2000,
-    }

--- a/wazimap_ng/config/production.py
+++ b/wazimap_ng/config/production.py
@@ -44,7 +44,3 @@ class Production(Common):
             'LOCATION': '/var/tmp/django_cache',
         }
     }
-
-    Q_CLUSTER = {
-       "orm": 'default',
-    }


### PR DESCRIPTION
@adieyal Please review

Only solution I was able to found for this issue is to raise retry time as docs suggested.

Conditions of the bug:

There is 2 type of configs in Django Q 
* Retry
* Timeout

Timeout set to None by default so task will never be timed out.

If we do not set Time out and task passes the retry time, We get current behaviour that we are getting in app. (Multiple Datasets)

If we set timeout than it will not create multiple datasets as process exceeding timeout values will be dropped but will be restarted again after reaching retry value.
So process will run in loop. Like this : 
<img width="1196" alt="Screenshot 2020-03-05 at 3 38 33 PM" src="https://user-images.githubusercontent.com/6871866/75971198-6d2fbe80-5ef7-11ea-8e53-74fb49c37d02.png">

