### PR TITLE
Fixed issue for comma breaking subindicator sortable widget

### DIFF
--- a/wazimap_ng/datasets/admin/dataset_admin.py
+++ b/wazimap_ng/datasets/admin/dataset_admin.py
@@ -74,6 +74,7 @@ class DatasetAdmin(BaseAdminModel):
                             instance.name
                         )
                     )
+
             if formset.deleted_objects:
                 variables_queryset = models.Indicator.objects.filter(id__in=[obj.id for obj in formset.deleted_objects])
                 variable_names = ", ".join(variables_queryset.values_list("name", flat=True))
@@ -103,8 +104,8 @@ class DatasetAdmin(BaseAdminModel):
             if dataset_obj and dataset_obj.datasetfile.task and dataset_obj.datasetfile.task.success:
 
                 if dataset_obj.indicator_set.count():
-                    inlines = inlines + (VariableInlinesChangeView, MetaDataInline,)
-                inlines = inlines + (VariableInlinesAddView, MetaDataInline,)
+                    inlines = inlines + (VariableInlinesChangeView,)
+                inlines = inlines + (VariableInlinesAddView,)
 
         self.inlines = inlines
         return super().change_view(request, object_id)

--- a/wazimap_ng/datasets/admin/profile_indicator_admin.py
+++ b/wazimap_ng/datasets/admin/profile_indicator_admin.py
@@ -1,9 +1,27 @@
 from django.contrib import admin
 from django.contrib.postgres import fields
+from django import forms
 
 from .. import models
 from .. import widgets
 from .utils import customTitledFilter, description
+from urllib.parse import unquote
+
+
+class ProfileIndicatorAdminForm(forms.ModelForm):
+    class Meta:
+        model = models.ProfileIndicator
+        fields = '__all__'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance.pk:
+            self.fields["subindicators"].widget = widgets.SortableWidget()
+            self.fields["subindicators"].widget.attrs["subindicators"] = self.instance.subindicators
+
+    def clean_subindicators(self):
+        data = self.cleaned_data['subindicators']
+        return [unquote(x) for x in data]
 
 @admin.register(models.ProfileIndicator)
 class ProfileIndicatorAdmin(admin.ModelAdmin):
@@ -22,6 +40,7 @@ class ProfileIndicatorAdmin(admin.ModelAdmin):
         "subcategory",
         "key_metric",
     )
+    form = ProfileIndicatorAdminForm
 
     fieldsets = (
         ("Database fields (can't change after being created)", {

--- a/wazimap_ng/datasets/static/js/sortable-widget.js
+++ b/wazimap_ng/datasets/static/js/sortable-widget.js
@@ -6,8 +6,7 @@ django.jQuery(document).ready(function($) {
             var reorderedSubindicators = [];
 	    	$parent.find("li").each(function(){
 	    		console.log($(this).data("val"));
-	    		reorderedSubindicators.push($(this).data('val'));
-	    		console.log(reorderedSubindicators.join(","));
+	    		reorderedSubindicators.push($(this).data('val').replace(",", "%2c"));
 	    		$input.val(reorderedSubindicators.join(","));
 	    	});
         },

--- a/wazimap_ng/datasets/widgets.py
+++ b/wazimap_ng/datasets/widgets.py
@@ -16,7 +16,11 @@ class SortableWidget(Widget):
         js = ("/static/js/jquery-ui.min.js", "/static/js/sortable-widget.js",)
 
     def get_context(self, name, value, attrs=None):
-        values_list = value.split(",") if value else []
+        values_list = []
+        if "subindicators" in self.attrs:
+            values_list = self.attrs["subindicators"]
+        else:
+            values_list = value.split(",") if value else []
         return {'widget': {
             'name': name,
             'values': {"list": values_list, "text": mark_safe(value)},


### PR DESCRIPTION
@adieyal Please review.

I was not able to find any ideal solution as this issue is bit tricky.
Also did not wanted to change field type.

So solution that I implemented is :

for GET : Send list of subindicators directly to widget rather than using string and splitting by `,`.
using string and split by `,` is still there as fallback option.

for POST : If there is comma in between subindicator string. Replace it by `%2c` as when we decode it in python it will become `,` and it's unique enough.
There wasn't any other way because we are using Array field and it automatically splits string by `,`.