### PR TITLE
feat: add codeclimate checks

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,24 @@
+version: "2"
+checks:
+  argument-count:
+    enabled: false
+  complex-logic:
+    enabled: false
+  file-lines:
+    enabled: false
+  method-complexity:
+    enabled: false
+  method-count:
+    enabled: false
+  method-lines:
+    enabled: false
+  nested-control-flow:
+    enabled: false
+  return-statements:
+    enabled: false
+plugins:
+  pep8:
+    enabled: false
+exclude_patterns:
+  - "tests/"
+  - "**/migrations/"


### PR DESCRIPTION
## Description

Use codeclimate for static analysis. but it should be included gradually. so we run duplication checks first
exclude the migrations folder, we don't need to check migrations. 
CodeClimate will only comment on PRs for now but will eventually be changed to inform the status (failed, pass).

## Related Issue

https://trello.com/c/wEP9HDto/460-code-quality-checks-on-pr-diffs