### PR TITLE
Show errors and error log file link for points upload

### DIFF
--- a/wazimap_ng/points/admin/coordinate_file_admin.py
+++ b/wazimap_ng/points/admin/coordinate_file_admin.py
@@ -3,6 +3,7 @@ import pandas as pd
 from .. import models
 from django.contrib import admin
 from django.urls import reverse
+from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.template.loader import render_to_string
 
@@ -56,11 +57,10 @@ class CoordinateFileAdmin(BaseAdminModel):
     def get_errors(self, obj):
         if obj.task and not obj.task.success:
             result = obj.task.result
-            if "CustomDataParsingExecption" in result:
+            if "CustomDataParsingException" in result:
                 logdir = settings.MEDIA_ROOT + "/logs/points/"
                 filename = "%s_%d_log.csv" % ("point_file", obj.id)
                 download_url = settings.MEDIA_URL + "logs/points/"
-
                 df = pd.read_csv(logdir+filename, header=None, sep=",", nrows=10, skiprows=1)
                 error_list = df.values.tolist()
 

--- a/wazimap_ng/points/dataloader.py
+++ b/wazimap_ng/points/dataloader.py
@@ -10,16 +10,16 @@ def loaddata(category, iterable, row_number):
     datarows = []
     logs = []
     for idx, row in enumerate(iterable):
-
+        line_no = row_number+idx+1
         if "longitude" not in row:
-            logs.append([row_number+idx+1, "longitude", "Missing Header Longitude"])
+            logs.append([line_no, "longitude", "Missing Header Longitude"])
 
         if "latitude" not in row:
-            logs.append([row_number+idx+1, "latitude", "Missing Header Latitude"])
+            logs.append([line_no, "latitude", "Missing Header Latitude"])
             continue
 
         if "name" not in row:
-            logs.append([row_number+idx+1, "name", "Missing Header Name"])
+            logs.append([line_no, "name", "Missing Header Name"])
             continue
 
         location = row.pop("name").strip()
@@ -27,35 +27,35 @@ def loaddata(category, iterable, row_number):
         latitude = row.pop("latitude")
 
         if not location.strip():
-            logs.append([row_number+idx+1, "Name", "Empty value for Name"])
+            logs.append([line_no, "Name", "Empty value for Name"])
             continue
 
         try:
             longitude = float(longitude)
         except Exception as e:
             if not longitude:
-                logs.append([row_number+idx+1, "longitude", "Empty value for longitude"])
+                logs.append([line_no, "longitude", "Empty value for longitude"])
             elif isinstance(longitude, str) and not longitude.isdigit():
-                logs.append([row_number+idx+1, "longitude", "Invalid value passed for longitude %s" % longitude])
+                logs.append([line_no, "longitude", "Invalid value passed for longitude %s" % longitude])
             else:
-                logs.append([row_number+idx+1, "longitude", e])
+                logs.append([line_no, "longitude", e])
             continue
 
         try:
             latitude = float(latitude)
         except Exception as e:
             if not latitude:
-                logs.append([row_number+idx+1, "latitude", "Empty value for latitude"])
+                logs.append([line_no, "latitude", "Empty value for latitude"])
             elif isinstance(latitude, str) and not latitude.isdigit():
-                logs.append([row_number+idx+1, "latitude", "Invalid value passed for latitude %s" % latitude])
+                logs.append([line_no, "latitude", "Invalid value passed for latitude %s" % latitude])
             else:
-                logs.append([row_number+idx+1, "latitude", e])
+                logs.append([line_no, "latitude", e])
             continue
 
         try:
             coordinates = Point(longitude, latitude)
         except Exception as e:
-            logs.append([row_number+idx+1, "Coordinates", "Issue while creating coordinates %s " % e])
+            logs.append([line_no, "Coordinates", "Issue while creating coordinates %s " % e])
             continue
 
         dd = models.Location(

--- a/wazimap_ng/points/dataloader.py
+++ b/wazimap_ng/points/dataloader.py
@@ -12,14 +12,14 @@ def loaddata(category, iterable, row_number):
     for idx, row in enumerate(iterable):
 
         if "longitude" not in row:
-            logs.append([row_number+idx, "longitude", "Missing Header Longitude"])
+            logs.append([row_number+idx+1, "longitude", "Missing Header Longitude"])
 
         if "latitude" not in row:
-            logs.append([row_number+idx, "latitude", "Missing Header Latitude"])
+            logs.append([row_number+idx+1, "latitude", "Missing Header Latitude"])
             continue
 
         if "name" not in row:
-            logs.append([row_number+idx, "name", "Missing Header Name"])
+            logs.append([row_number+idx+1, "name", "Missing Header Name"])
             continue
 
         location = row.pop("name").strip()
@@ -34,28 +34,28 @@ def loaddata(category, iterable, row_number):
             longitude = float(longitude)
         except Exception as e:
             if not longitude:
-                logs.append([row_number+idx, "longitude", "Empty value for longitude"])
+                logs.append([row_number+idx+1, "longitude", "Empty value for longitude"])
             elif isinstance(longitude, str) and not longitude.isdigit():
-                logs.append([row_number+idx, "longitude", "Invalid value passed for longitude %s" % longitude])
+                logs.append([row_number+idx+1, "longitude", "Invalid value passed for longitude %s" % longitude])
             else:
-                logs.append([row_number+idx, "longitude", e])
+                logs.append([row_number+idx+1, "longitude", e])
             continue
 
         try:
             latitude = float(latitude)
         except Exception as e:
             if not latitude:
-                logs.append([row_number+idx, "latitude", "Empty value for latitude"])
+                logs.append([row_number+idx+1, "latitude", "Empty value for latitude"])
             elif isinstance(latitude, str) and not latitude.isdigit():
-                logs.append([row_number+idx, "latitude", "Invalid value passed for latitude %s" % latitude])
+                logs.append([row_number+idx+1, "latitude", "Invalid value passed for latitude %s" % latitude])
             else:
-                logs.append([row_number+idx, "latitude", e])
+                logs.append([row_number+idx+1, "latitude", e])
             continue
 
         try:
             coordinates = Point(longitude, latitude)
         except Exception as e:
-            logs.append([row_number+idx, "Coordinates", "Issue while creating coordinates %s " % e])
+            logs.append([row_number+idx+1, "Coordinates", "Issue while creating coordinates %s " % e])
             continue
 
         dd = models.Location(
@@ -68,7 +68,7 @@ def loaddata(category, iterable, row_number):
         if len(datarows) >= 10000:
             models.Location.objects.bulk_create(datarows, 1000)
             datarows = []
-       
+
 
     models.Location.objects.bulk_create(datarows, 1000)
     return logs


### PR DESCRIPTION
@adieyal @milafrerichs Please review.
It's a small bug fix for showing errors while uploading points csv.

changelog:
* Line number was not accurate for created log file
* Custom error message template was not visible in admin panel.

So our current prod server will show this for errors:

<img width="1670" alt="Screenshot 2020-09-18 at 12 13 24 PM" src="https://user-images.githubusercontent.com/6871866/93565136-79b5c900-f9a8-11ea-86b9-0452244eef0e.png">

After this change is merged we will see errors like :

<img width="1679" alt="Screenshot 2020-09-18 at 12 08 26 PM" src="https://user-images.githubusercontent.com/6871866/93565073-5ee35480-f9a8-11ea-873a-ad7a1df0470b.png">
 
It will be good if we can get it merged and deployed today as jen is having difficulty in checking issues for failed points upload 