### PR TITLE
Removed duplicate code in filtering locations via geography

### DIFF
--- a/wazimap_ng/points/views.py
+++ b/wazimap_ng/points/views.py
@@ -52,12 +52,11 @@ class LocationList(generics.ListAPIView):
         try:
             profile_category = models.ProfileCategory.objects.get(id=profile_category_id)
             profile = Profile.objects.get(id=profile_id)
-            geography = None
-            if geography_code is not None:
-                version = profile.geography_hierarchy.version
-                geography = Geography.objects.get(code=geography_code, version=version)
 
-            queryset = get_locations(self.get_queryset(), profile, profile_category.category, geography)
+            queryset = get_locations(
+                self.get_queryset(), profile,
+                profile_category.category, geography_code
+            )
             serializer = self.get_serializer(queryset, many=True)
             data = serializer.data
             return Response(data)


### PR DESCRIPTION
@adieyal @milafrerichs Please review

There was duplicate code of get_locations and point views to filter by geography.
I have removed code from views and passed geography_code as argument to get_locations function.

All tests are passing on my local machine
