### PR TITLE
Added Unit tests for points location view & fixed breaking code accordingly

### DIFF
--- a/tests/points/factories.py
+++ b/tests/points/factories.py
@@ -1,9 +1,9 @@
 import factory
 
+from django.contrib.gis.geos import Point
+
 from wazimap_ng.points.models import Category, ProfileCategory, Theme, Location
 from tests.profile.factories import ProfileFactory
-
-from django.contrib.gis.geos import Point
 
 
 class ThemeFactory(factory.django.DjangoModelFactory):
@@ -13,12 +13,14 @@ class ThemeFactory(factory.django.DjangoModelFactory):
     profile = factory.SubFactory(ProfileFactory)
     name = "Theme"
 
+
 class CategoryFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = Category
 
     profile = factory.SubFactory(ProfileFactory)
     name = "Category"
+
 
 class ProfileCategoryFactory(factory.django.DjangoModelFactory):
     class Meta:

--- a/tests/points/factories.py
+++ b/tests/points/factories.py
@@ -1,7 +1,17 @@
 import factory
 
-from wazimap_ng.points.models import Category, ProfileCategory
+from wazimap_ng.points.models import Category, ProfileCategory, Theme, Location
 from tests.profile.factories import ProfileFactory
+
+from django.contrib.gis.geos import Point
+
+
+class ThemeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Theme
+
+    profile = factory.SubFactory(ProfileFactory)
+    name = "Theme"
 
 class CategoryFactory(factory.django.DjangoModelFactory):
     class Meta:
@@ -16,4 +26,15 @@ class ProfileCategoryFactory(factory.django.DjangoModelFactory):
 
     profile = factory.SubFactory(ProfileFactory)
     category = factory.SubFactory(CategoryFactory)
+    theme = factory.SubFactory(ThemeFactory)
+    label = "Pc Label"
 
+
+class LocationFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Location
+
+    category = factory.SubFactory(CategoryFactory)
+    name = "Location"
+    coordinates = Point(1.0, 1.0)
+    data = {}

--- a/tests/points/test_views.py
+++ b/tests/points/test_views.py
@@ -2,9 +2,13 @@ from test_plus import APITestCase
 import pytest
 
 from tests.profile.factories import ProfileFactory
-from tests.points.factories import ProfileCategoryFactory
+from tests.points.factories import (
+    ProfileCategoryFactory, ThemeFactory, CategoryFactory, LocationFactory
+)
 from tests.datasets.factories import GeographyFactory, GeographyHierarchyFactory
 from tests.boundaries.factories import GeographyBoundaryFactory
+
+from django.contrib.gis.geos import Point
 
 class TestCategoryView(APITestCase):
 
@@ -33,3 +37,187 @@ class TestThemeView(APITestCase):
         self.get("points-themes", profile_id=self.profile.pk)
         self.assert_http_200_ok()
 
+
+class TestLocationView(APITestCase):
+
+    def setUp(self):
+        self.profile = ProfileFactory()
+        self.theme = ThemeFactory(profile=self.profile)
+        self.category = CategoryFactory(profile=self.profile)
+        self.location = LocationFactory(category=self.category)
+        self.profile_category = ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme
+        )
+
+    def setup_geo_data(self):
+        geography = GeographyFactory(
+            version=self.profile.geography_hierarchy.root_geography.version
+        )
+        GeographyBoundaryFactory(geography=geography)
+        return geography
+
+
+    def test_nonexisting_profile(self):
+        """
+        Test if redirected to 404 when profile id is not valid
+        """
+        self.get(
+            "category-points", profile_id=1234,
+            profile_category_id=self.profile_category.id
+        )
+        self.assert_http_404_not_found()
+
+    def test_nonexisting_profile_category(self):
+        """
+        Test if redirected to 404 when profile category id is not valid
+        """
+        self.get(
+            "category-points", profile_id=self.profile.id,
+            profile_category_id=1234
+        )
+        self.assert_http_404_not_found()
+
+    def test_pc_location_view_without_geo_code(self):
+        """
+        Test location return data for following cases:
+
+          1) When there is location connected to catgeory of pc
+          2) When there are no locations linked to category of pc
+        """
+        # Test - condition 1
+        response = self.get(
+            "category-points", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"][0]["id"], self.location.id)
+
+        # Test - condition 2
+        # delete location
+        self.location.delete()
+        response = self.get(
+            "category-points", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"], [])
+
+    def test_invalid_profile_id_param(self):
+        """
+        Test to check if profile id and pc id are linked.
+        We should only fetch profile categories that are linked to
+        requested profile else throw 404
+
+        Test conditions:
+            1) pass profile id which is not linked to pc id
+            2) pass accurate profile id
+        """
+        # Test - condition 1
+        profile = ProfileFactory()
+        response = self.get(
+            "category-points", profile_id=profile.id,
+            profile_category_id=self.profile_category.id
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # Test - condition 2
+        response = self.get(
+            "category-points", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"][0]["id"], self.location.id)
+
+    def test_pc_location_view_with_geo_code(self):
+        """
+        Test location return data with valid geo code
+        """
+        geography = self.setup_geo_data()
+
+        response = self.get(
+            "category-points-geography", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id,
+            geography_code=geography.code
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"][0]["id"], self.location.id)
+
+    def test_pc_location_view_with_invalid_geo_data(self):
+        """
+        Test location return data with invalid version of geo data
+
+        Test conditions:
+            1) geography version not equal to profile hierarchy version
+            2) Missing boundary object for geography_code
+            3) Accurate data so we can check if points are returned in api
+            4) Change location point coords to outside of geo boundary to check
+               response when location queryset is empty
+        """
+        geography = GeographyFactory()
+        profile_version = self.profile.geography_hierarchy.root_geography.version
+
+        # condition - 1
+        self.assertNotEqual(geography.version, profile_version)
+
+        response = self.get(
+            "category-points-geography", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id,
+            geography_code=geography.code
+        )
+        self.assertEqual(response.status_code, 404)
+
+        # condition - 2
+        # Change version of geography to match with profile
+        geography.version = profile_version
+        geography.save()
+
+        response = self.get(
+            "category-points-geography", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id,
+            geography_code=geography.code
+        )
+        # 404 because of Missing boundary data
+        self.assertEqual(response.status_code, 404)
+
+        # condition - 3
+        # create boundary
+        GeographyBoundaryFactory(geography=geography)
+
+        response = self.get(
+            "category-points-geography", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id,
+            geography_code=geography.code
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"][0]["id"], self.location.id)
+
+        # condition - 4
+        # Set Location point outside GeographyBoundary
+        self.location.coordinates = Point(70.0, 70.0)
+        self.location.save()
+
+        response = self.get(
+            "category-points-geography", profile_id=self.profile.id,
+            profile_category_id=self.profile_category.id,
+            geography_code=geography.code
+        )
+        self.assertEqual(response.status_code, 200)
+        data = response.data
+
+        self.assertEqual(data["type"], "FeatureCollection")
+        self.assertEqual(data["features"], [])

--- a/tests/points/test_views.py
+++ b/tests/points/test_views.py
@@ -1,6 +1,8 @@
 from test_plus import APITestCase
 import pytest
 
+from django.contrib.gis.geos import Point
+
 from tests.profile.factories import ProfileFactory
 from tests.points.factories import (
     ProfileCategoryFactory, ThemeFactory, CategoryFactory, LocationFactory
@@ -8,7 +10,6 @@ from tests.points.factories import (
 from tests.datasets.factories import GeographyFactory, GeographyHierarchyFactory
 from tests.boundaries.factories import GeographyBoundaryFactory
 
-from django.contrib.gis.geos import Point
 
 class TestCategoryView(APITestCase):
 
@@ -55,7 +56,6 @@ class TestLocationView(APITestCase):
         )
         GeographyBoundaryFactory(geography=geography)
         return geography
-
 
     def test_nonexisting_profile(self):
         """

--- a/tests/points/test_views.py
+++ b/tests/points/test_views.py
@@ -15,7 +15,7 @@ class TestCategoryView(APITestCase):
 
     def setUp(self):
         self.profile = ProfileFactory()
-        self.profile_category = ProfileCategoryFactory()
+        self.profile_category = ProfileCategoryFactory(profile=self.profile)
 
     def test_category_points_list(self):
         self.get('category-points', profile_id=self.profile.pk, profile_category_id=self.profile_category.pk, extra={'format': 'json'})
@@ -26,7 +26,8 @@ class TestCategoryView(APITestCase):
         GeographyBoundaryFactory(geography=geography)
         hierarchy = GeographyHierarchyFactory(root_geography=geography)
         profile = ProfileFactory(geography_hierarchy=hierarchy)
-        self.get('category-points-geography', profile_id=profile.pk, profile_category_id=self.profile_category.pk, geography_code=geography.code, extra={'format': 'json'})
+        profile_category = ProfileCategoryFactory(profile=profile)
+        self.get('category-points-geography', profile_id=profile.pk, profile_category_id=profile_category.pk, geography_code=geography.code, extra={'format': 'json'})
         self.assert_http_200_ok()
 
 class TestThemeView(APITestCase):

--- a/wazimap_ng/config/test.py
+++ b/wazimap_ng/config/test.py
@@ -1,22 +1,18 @@
 import os
-from .common import Common
+from .local import Local
 from configurations import Configuration, values
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-class Test(Common):
+class Test(Local):
 
-    INSTALLED_APPS = Common.INSTALLED_APPS
+    INSTALLED_APPS = Local.INSTALLED_APPS
     SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
     NOSE_ARGS = [
         BASE_DIR,
-        '-s',
-        '--nologcapture',
-        '--with-coverage',
-        '--with-progressive',
-        '--cover-package=wazimap_ng'
+        "--verbose",
     ]
 
     # Mail

--- a/wazimap_ng/config/test.py
+++ b/wazimap_ng/config/test.py
@@ -1,18 +1,22 @@
 import os
-from .local import Local
+from .common import Common
 from configurations import Configuration, values
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-class Test(Local):
+class Test(Common):
 
-    INSTALLED_APPS = Local.INSTALLED_APPS
+    INSTALLED_APPS = Common.INSTALLED_APPS
     SECRET_KEY = os.getenv('DJANGO_SECRET_KEY')
 
     TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
     NOSE_ARGS = [
         BASE_DIR,
-        "--verbose",
+        '-s',
+        '--nologcapture',
+        '--with-coverage',
+        '--with-progressive',
+        '--cover-package=wazimap_ng'
     ]
 
     # Mail


### PR DESCRIPTION
## Description
@milafrerichs Please review
I was writing test for PR: https://github.com/OpenUpSA/wazimap-ng/pull/117 when I saw that you have already created point factories. So I have extended that branch to include tests and fixes for PR mentioned above.

I found couple of more issues/bugs in points location views so I have written tests for each condition and fixed bugs accordingly.

PS: I have still not closed PR: https://github.com/OpenUpSA/wazimap-ng/pull/117. Will do according to your review on this PR

## Related Issue
https://trello.com/c/lLztLvzW/474-bug-point-download-is-broken-does-nothing#comment-5f689e697b2ed369946bb6c9

## How to test it locally

* url `api/v1/profile/<int:profile_id>/points/category/<int:profile_category_id>/geography/<str:geography_code>/points/` should not throw 404.

## Changelog

* Added tests for points location view
* Removed duplicate code
* Check if profile category id passed in url belongs to the requested profile.
   Right now our system is returning data even if profile category does not belong to profile.
* Added and changed point factories

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
