### PR TITLE
Add more info about error logs in csv uploads

### DIFF
--- a/wazimap_ng/datasets/admin/dataset_file_admin.py
+++ b/wazimap_ng/datasets/admin/dataset_file_admin.py
@@ -148,10 +148,14 @@ class DatasetFileAdmin(BaseAdminModel):
                 return obj.task.result
             elif result["error_log"]:
                 download_url = result["error_log"].replace("/app", "")
+                incorrect_csv = result["incorrect_rows_log"].replace("/app", "")
                 df = pd.read_csv(result["error_log"], header=None, sep=",", nrows=10, skiprows=1)
                 error_list = df.values.tolist()
                 result = render_to_string(
-                    'custom/variable_task_errors.html', { 'errors': error_list,'download_url': download_url}
+                    'custom/variable_task_errors.html', {
+                        'errors': error_list,'download_url': download_url,
+                        'incorrect_csv': incorrect_csv
+                    }
                 )
                 return mark_safe(result)
         return "None"
@@ -166,4 +170,3 @@ class DatasetFileAdmin(BaseAdminModel):
 
     def has_change_permission(self, request, obj=None):
         return False
-

--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -17,6 +17,7 @@ def load_geography(geo_code, version):
     geography = models.Geography.objects.get(code=geo_code, version=version)
     return geography
 
+
 def create_groups(dataset, group_names):
     groups = []
     for g in group_names:
@@ -25,8 +26,9 @@ def create_groups(dataset, group_names):
         groups.append(group)
     return groups
 
+
 @transaction.atomic
-def loaddata(dataset, iterable, row_number):  
+def loaddata(dataset, iterable, row_number):
     datarows = []
     errors = []
     warnings = []
@@ -37,20 +39,23 @@ def loaddata(dataset, iterable, row_number):
     for idx, row in enumerate(iterable):
         groups |= set(x for x in row.keys())
         geo_code = row["geography"]
+        line_no = row_number+idx+1
+        error_lines = []
         try:
             geography = load_geography(geo_code, version)
         except models.Geography.DoesNotExist:
             warnings.append(list(row.values()))
             continue
 
-
         try:
             count = float(row["count"])
             if math.isnan(count):
-                errors.append([row_number+idx, "count", "Missing data for count"])
-                continue
+                error_lines.append([line_no, "count", "Missing data for count"])
         except (TypeError, ValueError):
-            errors.append([row_number+idx, "count", f"""Expected a number in the 'count' column, received '{row["count"]}'"""])
+            error_lines.append([line_no, "count", f"""Expected a number in the 'count' column, received '{row["count"]}'"""])
+
+        if error_lines:
+            errors.append([error_lines, list(row.values())])
             continue
 
         del row["geography"]

--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -50,12 +50,24 @@ def loaddata(dataset, iterable, row_number):
         try:
             count = float(row["count"])
             if math.isnan(count):
-                error_lines.append([line_no, "count", "Missing data for count"])
+                error_lines.append({
+                    "CSV Line Number": line_no,
+                    "Field Name": "count",
+                    "Error Details": "Missing data for count"
+                })
+
         except (TypeError, ValueError):
-            error_lines.append([line_no, "count", f"""Expected a number in the 'count' column, received '{row["count"]}'"""])
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "count",
+                "Error Details": f"Expected a number in the 'count' column, received {row['count']}"
+            })
 
         if error_lines:
-            errors.append([error_lines, list(row.values())])
+            errors.append({
+                "line_error": error_lines,
+                "values": list(row.values())
+            })
             continue
 
         del row["geography"]

--- a/wazimap_ng/datasets/templates/custom/variable_task_errors.html
+++ b/wazimap_ng/datasets/templates/custom/variable_task_errors.html
@@ -3,10 +3,11 @@
 	<p>Sample Error: </p>
       <ul style="margin-left: 20px;">
         {% for error in errors %}
-            <li>Error : {{error.2}} on line {{ error.0 }} </li>
+            <li>Error : {{error.2}} on line {{ error.1 }} </li>
           {% empty %}
             <p>Empty error log</p>
           {% endfor %}
       </ul>
       <p>For more info on errors by lines : <a href="{{ download_url }}">Error Log File</a></p>
+      <p>To get all the incorrect rows please download : <a href="{{ incorrect_csv }}">Incorrect Rows CSV</a></p>
 </div>

--- a/wazimap_ng/general/services/csv_helpers.py
+++ b/wazimap_ng/general/services/csv_helpers.py
@@ -1,0 +1,57 @@
+import os
+
+import pandas as pd
+from django.conf import settings
+
+
+def get_log_filename(name, type, file_id):
+    return F"{name}_{file_id}_{type}_log.csv"
+
+
+def write_csv(logs, logfile, headers):
+    df = pd.DataFrame(logs)
+    df.to_csv(logfile, header=headers, index=False)
+    return logfile
+
+
+def csv_error_logger(logdir, target_name, target_id, logs, headers):
+    errors = []
+    incorrect_rows = []
+
+    for idx, log in enumerate(logs):
+        errors = errors + [[idx+1] + error for error in log[0]]
+        incorrect_rows.append(log[1])
+
+    error_file_name = get_log_filename(target_name, "errors", target_id)
+    error_file_log = write_csv(
+        errors, F"{logdir}/{error_file_name}", [
+            "Error file line no.", "Actual csv line no.", "Field Name",
+            "Error Details"
+        ]
+    )
+    incorrect_file_name = get_log_filename(
+        target_name, "incorrect_rows", target_id
+    )
+    incorrect_file_log = write_csv(
+        incorrect_rows, F"{logdir}/{incorrect_file_name}", headers
+    )
+
+    return error_file_log, incorrect_file_log
+
+
+def csv_logger(target_obj, file_obj, type, logs, headers):
+    results=[]
+    logdir=F"{settings.MEDIA_ROOT}/logs/{target_obj._meta.verbose_name}/{type}"
+    if not os.path.exists(logdir):
+        os.makedirs(logdir)
+
+    target_name=target_obj.name.replace(" ", "_")
+    target_id=file_obj.id
+
+    if type == "error":
+        results=csv_error_logger(logdir, target_name, target_id, logs, headers)
+    else:
+        log_file_name = get_log_filename(target_name, type, target_id)
+        file_log = write_csv(logs, F"{logdir}/{log_file_name}", headers)
+        results.append(file_log)
+    return results

--- a/wazimap_ng/points/dataloader.py
+++ b/wazimap_ng/points/dataloader.py
@@ -14,48 +14,84 @@ def loaddata(category, iterable, row_number):
         row_list = list(row.values())
         error_lines = []
         if "longitude" not in row:
-            error_lines.append([line_no, "longitude", "Missing Header Longitude"])
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "longitude",
+                "Error Details": "Missing Header Longitude"
+            })
 
         if "latitude" not in row:
-            error_lines.append([line_no, "latitude", "Missing Header Latitude"])
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "latitude",
+                "Error Details": "Missing Header Latitude"
+            })
 
         if "name" not in row:
-            error_lines.append([line_no, "name", "Missing Header Name"])
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "name",
+                "Error Details": "Missing Header Name"
+            })
 
         location = row.pop("name").strip()
         longitude = row.pop("longitude")
         latitude = row.pop("latitude")
 
         if not location.strip():
-            error_lines.append([line_no, "Name", "Empty value for Name"])
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "Name",
+                "Error Details": "Empty value for Name"
+            })
+
 
         try:
             longitude = float(longitude)
         except Exception as e:
             if not longitude:
-                error_lines.append([line_no, "longitude", "Empty value for longitude"])
+                msg = "Empty value for longitude"
             elif isinstance(longitude, str) and not longitude.isdigit():
-                error_lines.append([line_no, "longitude", "Invalid value passed for longitude %s" % longitude])
+                msg = F"Invalid value passed for longitude {longitude}"
             else:
-                error_lines.append([line_no, "longitude", e])
+                msg = e
+
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "longitude",
+                "Error Details": msg
+            })
 
         try:
             latitude = float(latitude)
         except Exception as e:
             if not latitude:
-                error_lines.append([line_no, "latitude", "Empty value for latitude"])
+                msg = "Empty value for latitude"
             elif isinstance(latitude, str) and not latitude.isdigit():
-                error_lines.append([line_no, "latitude", "Invalid value passed for latitude %s" % latitude])
+                msg = F"Invalid value passed for latitude {latitude}"
             else:
-                error_lines.append([line_no, "latitude", e])
+                msg = e
+
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "latitude",
+                "Error Details": msg
+            })
 
         try:
             coordinates = Point(longitude, latitude)
         except Exception as e:
-            error_lines.append([line_no, "Coordinates", "Issue while creating coordinates %s " % e])
+            error_lines.append({
+                "CSV Line Number": line_no,
+                "Field Name": "Coordinates",
+                "Error Details": F"Issue while creating coordinates {e}"
+            })
 
         if error_lines:
-            logs.append([error_lines, row_list])
+            logs.append({
+                "line_error": error_lines,
+                "values": row_list
+            })
             continue
 
         dd = models.Location(

--- a/wazimap_ng/points/dataloader.py
+++ b/wazimap_ng/points/dataloader.py
@@ -11,51 +11,51 @@ def loaddata(category, iterable, row_number):
     logs = []
     for idx, row in enumerate(iterable):
         line_no = row_number+idx+1
+        row_list = list(row.values())
+        error_lines = []
         if "longitude" not in row:
-            logs.append([line_no, "longitude", "Missing Header Longitude"])
+            error_lines.append([line_no, "longitude", "Missing Header Longitude"])
 
         if "latitude" not in row:
-            logs.append([line_no, "latitude", "Missing Header Latitude"])
-            continue
+            error_lines.append([line_no, "latitude", "Missing Header Latitude"])
 
         if "name" not in row:
-            logs.append([line_no, "name", "Missing Header Name"])
-            continue
+            error_lines.append([line_no, "name", "Missing Header Name"])
 
         location = row.pop("name").strip()
         longitude = row.pop("longitude")
         latitude = row.pop("latitude")
 
         if not location.strip():
-            logs.append([line_no, "Name", "Empty value for Name"])
-            continue
+            error_lines.append([line_no, "Name", "Empty value for Name"])
 
         try:
             longitude = float(longitude)
         except Exception as e:
             if not longitude:
-                logs.append([line_no, "longitude", "Empty value for longitude"])
+                error_lines.append([line_no, "longitude", "Empty value for longitude"])
             elif isinstance(longitude, str) and not longitude.isdigit():
-                logs.append([line_no, "longitude", "Invalid value passed for longitude %s" % longitude])
+                error_lines.append([line_no, "longitude", "Invalid value passed for longitude %s" % longitude])
             else:
-                logs.append([line_no, "longitude", e])
-            continue
+                error_lines.append([line_no, "longitude", e])
 
         try:
             latitude = float(latitude)
         except Exception as e:
             if not latitude:
-                logs.append([line_no, "latitude", "Empty value for latitude"])
+                error_lines.append([line_no, "latitude", "Empty value for latitude"])
             elif isinstance(latitude, str) and not latitude.isdigit():
-                logs.append([line_no, "latitude", "Invalid value passed for latitude %s" % latitude])
+                error_lines.append([line_no, "latitude", "Invalid value passed for latitude %s" % latitude])
             else:
-                logs.append([line_no, "latitude", e])
-            continue
+                error_lines.append([line_no, "latitude", e])
 
         try:
             coordinates = Point(longitude, latitude)
         except Exception as e:
-            logs.append([line_no, "Coordinates", "Issue while creating coordinates %s " % e])
+            error_lines.append([line_no, "Coordinates", "Issue while creating coordinates %s " % e])
+
+        if error_lines:
+            logs.append([error_lines, row_list])
             continue
 
         dd = models.Location(
@@ -68,7 +68,6 @@ def loaddata(category, iterable, row_number):
         if len(datarows) >= 10000:
             models.Location.objects.bulk_create(datarows, 1000)
             datarows = []
-
 
     models.Location.objects.bulk_create(datarows, 1000)
     return logs


### PR DESCRIPTION
## Description
Added Incorrect csv log rows with error logs of csv upload.
Changed ways for logging errors in csv uploads
Point uploads will not fail if there are errors in uploaded csv
## Related Issue
https://github.com/OpenUpSA/wazimap-ng/pull/113#issuecomment-700279710

## How to test it locally
Get a dataset file or coordinate file with errors.
After upload we should get option to download error log and incorrect csv rows in file admin.

## Changelog

* Made a common function to log upload errors
* Added incorrect csv rows log
* Changed dataloader, admin, upload task , error templates accordingly

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
