### PR TITLE
Fix file extension for uploaded dataset file #125

### DIFF
--- a/wazimap_ng/datasets/admin/dataset_file_admin.py
+++ b/wazimap_ng/datasets/admin/dataset_file_admin.py
@@ -84,8 +84,10 @@ class DatasetFileAdmin(BaseAdminModel):
     get_dataset_name.short_description = 'Dataset'
 
     def get_document(self, obj):
+        file_extension = obj.document.name.split(".")[-1]
+        doc_name = f'{obj.name}-{obj.id}.{file_extension}'
         return mark_safe(
-            f'<a href="{obj.document.url}" download="{obj.name}-{obj.id}.csv">{obj.name}-{obj.id}.csv</a>'
+            f'<a href="{obj.document.url}" download="{doc_name}">{doc_name}</a>'
         )
 
     get_document.short_description = 'Document'
@@ -166,4 +168,3 @@ class DatasetFileAdmin(BaseAdminModel):
 
     def has_change_permission(self, request, obj=None):
         return False
-


### PR DESCRIPTION
## Description
xlsx file was downloaded with a csv extension and it was throwing warning when opened in excel.
Fixed it by making extension dynamic

## Related Issue
https://github.com/OpenUpSA/wazimap-ng/issues/125

## How to test it locally
upload a xlsx file in dataset upload.
Check dataset file and there should be a download link for document.
This downloaded document should not show warning for opening file in excel.

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
