### PR TITLE
Cache does not currently invalidate with change to group or subindicators #124

### DIFF
--- a/tests/datasets/factories.py
+++ b/tests/datasets/factories.py
@@ -24,7 +24,8 @@ class DatasetFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Dataset
 
-    geography_hierarchy = factory.SubFactory(GeographyHierarchyFactory)
+    profile = factory.SubFactory("tests.profile.factories.ProfileFactory")
+    geography_hierarchy = factory.SelfAttribute('profile.geography_hierarchy')
 
 
 class UniverseFactory(factory.django.DjangoModelFactory):
@@ -55,4 +56,3 @@ class GroupFactory(factory.django.DjangoModelFactory):
         model = models.Group
 
     dataset = factory.SubFactory(DatasetFactory)
-

--- a/tests/datasets/factories.py
+++ b/tests/datasets/factories.py
@@ -56,3 +56,14 @@ class GroupFactory(factory.django.DjangoModelFactory):
         model = models.Group
 
     dataset = factory.SubFactory(DatasetFactory)
+
+
+class DatasetDataFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.DatasetData
+
+    geography = factory.SubFactory(GeographyFactory)
+    dataset = factory.SubFactory(DatasetFactory)
+    data = {}
+
+

--- a/tests/profile/test_views.py
+++ b/tests/profile/test_views.py
@@ -12,7 +12,10 @@ class TestProfileGeographyData(APITestCase):
 
     def setUp(self):
         self.profile = ProfileFactory()
-        dataset = DatasetFactory(geography_hierarchy=self.profile.geography_hierarchy, groups=["age group", "gender"])
+        dataset = DatasetFactory(
+            geography_hierarchy=self.profile.geography_hierarchy, groups=["age group", "gender"],
+            profile=self.profile
+        )
         indicator = IndicatorFactory(name="Age by Gender", dataset=dataset, groups=["gender"])
 
         category = IndicatorCategoryFactory(name="Category", profile=self.profile)
@@ -76,4 +79,3 @@ class TestProfileGeographyData(APITestCase):
         age_group = groups.get('age group')
 
         assert age_group != wrong_order
-

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -8,7 +8,7 @@ import pytest
 from django.core.cache import cache as django_cache
 
 from tests.profile.factories import ProfileIndicatorFactory, ProfileKeyMetricsFactory, ProfileHighlightFactory
-from tests.datasets.factories import  IndicatorFactory
+from tests.datasets.factories import  IndicatorFactory, GeographyFactory, DatasetDataFactory, GroupFactory
 from wazimap_ng import cache
 
 
@@ -158,3 +158,25 @@ class TestCache(unittest.TestCase):
             call(profile_indicator_obj.profile)
         ]
         mock_update_profile_cache.assert_has_calls(calls, any_order=True)
+
+    @patch('wazimap_ng.cache.update_profile_cache', autospec=True)
+    def test_invalidate_profile_cache_for_geography_udpate(self, mock_update_profile_cache):
+        mock_update_profile_cache.reset_mock()
+        geography = GeographyFactory()
+        datasetdata = DatasetDataFactory(geography=geography)
+        self.assertEqual(mock_update_profile_cache.call_count, 1)
+        calls = [
+            call(datasetdata.dataset.profile),
+        ]
+        mock_update_profile_cache.assert_has_calls(calls, any_order=True)
+
+    @patch('wazimap_ng.cache.update_profile_cache', autospec=True)
+    def test_invalidate_profile_cache_for_group_udpate(self, mock_update_profile_cache):
+        mock_update_profile_cache.reset_mock()
+        group = GroupFactory()
+        self.assertEqual(mock_update_profile_cache.call_count, 2)
+        calls = [
+            call(group.dataset.profile),
+        ]
+        mock_update_profile_cache.assert_has_calls(calls, any_order=True)
+


### PR DESCRIPTION
# Description
There were couple of issues :

* Duplicate function name for updating profile cache when profile indicator is ssaved.
* Added signals for cache update in case of geography update or subindicators group update
* Changed how dataset factory works to include profile subfactory and getting hierarchy from profile rather than creating new factory for  hierarchy
* All tests are passing but I recommend to make profile required on DB level so we are forced to add required data in tests when using factories.

## Related Issue
#124 


## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
