### PR TITLE
Fixed upload of csvs with non-standard encodings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -78,3 +78,4 @@ django-guardian==2.2.0
 
 django-mock-queries==2.1.5
 lorem==0.1.1
+chardet==3.0.4

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -7,6 +7,17 @@ import pytest
 from wazimap_ng.datasets.tasks.process_uploaded_file import process_csv
 from tests.datasets.factories import DatasetFactory, GeographyFactory, GeographyHierarchyFactory
 
+def generate_file(data):
+    fp = tempfile.NamedTemporaryFile("w", delete=False)
+    writer = csv.writer(fp)
+    writer.writerow(["Geography", "field1", "field2", "count"])
+    writer.writerows(data)
+    filename = fp.name
+    fp.close()
+
+    return filename
+
+
 @pytest.fixture
 def geography_hierarchy():
     hierarchy = GeographyHierarchyFactory()
@@ -25,34 +36,25 @@ def dataset(geography_hierarchy):
     return DatasetFactory(geography_hierarchy=geography_hierarchy)
 
 @pytest.fixture
-def csv_file(geographies):
-    fp = tempfile.NamedTemporaryFile("w", delete=False)
-    writer = csv.writer(fp)
-    writer.writerow(["Geography", "field1", "field2", "count"])
-    writer.writerow([geographies[0].code, "F1_value_1", "F2_value_1", 111])
-    writer.writerow([geographies[1].code, "F1_value_2", "F2_value_2", 222])
-    filename = fp.name
-    fp.close()
-
-    return filename
-
+def good_data(geographies):
+    return [
+        (geographies[0].code, "F1_value_1", "F2_value_1", 111),
+        (geographies[1].code, "F1_value_2", "F2_value_2", 222),
+    ]
 
 @pytest.mark.django_db
 class TestUploadFile:
 
-    def test_process_csv(self, dataset, csv_file, geographies):
-        process_csv(dataset, csv_file)
+    def test_process_csv(self, dataset, good_data, geographies):
+        filename = generate_file(good_data)
+        process_csv(dataset, filename)
+
         datasetdata = dataset.datasetdata_set.all()
-        assert len(datasetdata) == 2
 
-        dd1 = datasetdata[0]
-        dd2 = datasetdata[1]
+        assert len(datasetdata) == len(good_data)
 
-        assert dd1.geography == geographies[0]
-        assert dd2.geography == geographies[1]
-
-
-        assert dd1.data["field1"] == "F1_value_1"
-        assert dd1.data["field2"] == "F2_value_1"
-        assert dd2.data["field1"] == "F1_value_2"
-        assert dd2.data["field2"] == "F2_value_2"
+        for dd, ed in zip(datasetdata, good_data):
+            assert dd.geography.code == ed[0]
+            assert dd.data["field1"] == ed[1]
+            assert dd.data["field2"] == ed[2]
+            assert dd.data["count"] == str(ed[3])

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -1,0 +1,58 @@
+from unittest.mock import patch
+import csv
+import tempfile
+
+import pytest
+
+from wazimap_ng.datasets.tasks.process_uploaded_file import process_csv
+from tests.datasets.factories import DatasetFactory, GeographyFactory, GeographyHierarchyFactory
+
+@pytest.fixture
+def geography_hierarchy():
+    hierarchy = GeographyHierarchyFactory()
+
+    return hierarchy
+
+@pytest.fixture
+def geographies(geography_hierarchy):
+    geo1 = GeographyFactory(code="GEOCODE_1", version=geography_hierarchy.version)
+    geo2 = GeographyFactory(code="GEOCODE_2", version=geography_hierarchy.version)
+
+    return [geo1, geo2]
+
+@pytest.fixture
+def dataset(geography_hierarchy):
+    return DatasetFactory(geography_hierarchy=geography_hierarchy)
+
+@pytest.fixture
+def csv_file(geographies):
+    fp = tempfile.NamedTemporaryFile("w", delete=False)
+    writer = csv.writer(fp)
+    writer.writerow(["Geography", "field1", "field2", "count"])
+    writer.writerow([geographies[0].code, "F1_value_1", "F2_value_1", 111])
+    writer.writerow([geographies[1].code, "F1_value_2", "F2_value_2", 222])
+    filename = fp.name
+    fp.close()
+
+    return filename
+
+
+@pytest.mark.django_db
+class TestUploadFile:
+
+    def test_process_csv(self, dataset, csv_file, geographies):
+        process_csv(dataset, csv_file)
+        datasetdata = dataset.datasetdata_set.all()
+        assert len(datasetdata) == 2
+
+        dd1 = datasetdata[0]
+        dd2 = datasetdata[1]
+
+        assert dd1.geography.code == geographies[0].code
+        assert dd2.geography.code == geographies[1].code
+
+
+        assert dd1.data["field1"] == "F1_value_1"
+        assert dd1.data["field2"] == "F2_value_1"
+        assert dd2.data["field1"] == "F1_value_2"
+        assert dd2.data["field2"] == "F2_value_2"

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 import csv
+from pathlib import Path
 import tempfile
 
 import pytest
@@ -70,3 +71,9 @@ class TestUploadFile:
             assert dd.data["field1"] == ed[1]
             assert dd.data["field2"] == ed[2]
             assert dd.data["count"] == str(ed[3])
+
+        path = Path(filename)
+        if path.exists():
+            path.unlink()
+
+

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -48,8 +48,8 @@ class TestUploadFile:
         dd1 = datasetdata[0]
         dd2 = datasetdata[1]
 
-        assert dd1.geography.code == geographies[0].code
-        assert dd2.geography.code == geographies[1].code
+        assert dd1.geography == geographies[0]
+        assert dd2.geography == geographies[1]
 
 
         assert dd1.data["field1"] == "F1_value_1"

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -35,25 +35,32 @@ def geographies(geography_hierarchy):
 def dataset(geography_hierarchy):
     return DatasetFactory(geography_hierarchy=geography_hierarchy)
 
-@pytest.fixture
-def good_data(geographies):
-    return [
-        (geographies[0].code, "F1_value_1", "F2_value_1", 111),
-        (geographies[1].code, "F1_value_2", "F2_value_2", 222),
-    ]
+good_data = [
+    ("GEOCODE_1", "F1_value_1", "F2_value_1", 111),
+    ("GEOCODE_2", "F1_value_2", "F2_value_2", 222),
+]
+
+data_with_different_case = [
+    ("GEOCODE_1", "f1_VALue_1", "F2_value_1", 111),
+    ("GEOCODE_2", "F1_value_2", "f2_valUE_2", 222),
+]
+
+@pytest.fixture(params=[good_data, data_with_different_case])
+def data(request):
+    return request.param
+
 
 @pytest.mark.django_db
 class TestUploadFile:
-
-    def test_process_csv(self, dataset, good_data, geographies):
-        filename = generate_file(good_data)
+    def test_process_csv(self, dataset, data, geographies):
+        filename = generate_file(data)
         process_csv(dataset, filename)
 
         datasetdata = dataset.datasetdata_set.all()
 
-        assert len(datasetdata) == len(good_data)
+        assert len(datasetdata) == len(data)
 
-        for dd, ed in zip(datasetdata, good_data):
+        for dd, ed in zip(datasetdata, data):
             assert dd.geography.code == ed[0]
             assert dd.data["field1"] == ed[1]
             assert dd.data["field2"] == ed[2]

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -7,8 +7,8 @@ import pytest
 from wazimap_ng.datasets.tasks.process_uploaded_file import process_csv
 from tests.datasets.factories import DatasetFactory, GeographyFactory, GeographyHierarchyFactory
 
-def generate_file(data):
-    fp = tempfile.NamedTemporaryFile("w", delete=False)
+def generate_file(data, encoding="utf8"):
+    fp = tempfile.NamedTemporaryFile("w", delete=False, encoding=encoding)
     writer = csv.writer(fp)
     writer.writerow(["Geography", "field1", "field2", "count"])
     writer.writerows(data)
@@ -45,7 +45,12 @@ data_with_different_case = [
     ("GEOCODE_2", "F1_value_2", "f2_valUE_2", 222),
 ]
 
-@pytest.fixture(params=[good_data, data_with_different_case])
+data_with_different_encodings = [
+    ("GEOCODE_1", "‘F1_value_1", "F2_value_1’", 111),
+    ("GEOCODE_2", "€ŠF1_value_2", "F2_value_2®®", 222),
+]
+
+@pytest.fixture(params=[good_data, data_with_different_case, data_with_different_encodings])
 def data(request):
     return request.param
 

--- a/wazimap_ng/datasets/tasks/__init__.py
+++ b/wazimap_ng/datasets/tasks/__init__.py
@@ -1,3 +1,6 @@
 from .process_uploaded_file import process_uploaded_file
+from .process_uploaded_file import process_file_data
+from .process_uploaded_file import process_csv
+
 from .indicator_data_extraction import indicator_data_extraction
 from .delete_data import delete_data

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -13,6 +13,33 @@ from wazimap_ng.general.services.csv_helpers import csv_logger
 
 logger = logging.getLogger(__name__)
 
+def process_file_data(df, dataset, row_number):
+    df = df.applymap(lambda s:s.capitalize().strip() if type(s) == str else s)
+    datasource = (dict(d[1]) for d in df.iterrows())
+    return loaddata(dataset, datasource, row_number)
+
+def process_csv(dataset, filename, chunksize=1000000):
+    row_number = 1
+    df = pd.read_csv(filename, nrows=1, dtype=str, sep=",")
+    df.dropna(how='all', axis='columns', inplace=True)
+    columns = df.columns.str.lower()
+    error_logs = [];
+    warning_logs = [];
+
+    for df in pd.read_csv(filename, chunksize=chunksize, dtype=str, sep=",", header=None, skiprows=1):
+        df.dropna(how='all', axis='columns', inplace=True)
+        df.columns = columns
+        errors, warnings = process_file_data(df, dataset, row_number)
+        error_logs = error_logs + errors
+        warning_logs = warning_logs + warnings
+        row_number = row_number + chunksize
+
+    return {
+        "error_logs": error_logs,
+        "warning_logs": warning_logs,
+        "columns": columns
+    }
+
 
 @transaction.atomic
 def process_uploaded_file(dataset_file, dataset, **kwargs):
@@ -25,10 +52,6 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     Get header index for geography & count and create Result objects.
     """
-    def process_file_data(df, dataset, row_number):
-        df = df.applymap(lambda s:s.capitalize().strip() if type(s) == str else s)
-        datasource = (dict(d[1]) for d in df.iterrows())
-        return loaddata(dataset, datasource, row_number)
 
     filename = dataset_file.document.name
     chunksize = getattr(settings, "CHUNK_SIZE_LIMIT", 1000000)
@@ -41,17 +64,10 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     if ".csv" in filename:
         logger.debug(f"Processing as csv")
-        df = pd.read_csv(dataset_file.document.open(), nrows=1, dtype=str, sep=",")
-        df.dropna(how='all', axis='columns', inplace=True)
-        columns = df.columns.str.lower()
-
-        for df in pd.read_csv(dataset_file.document.open(), chunksize=chunksize, dtype=str, sep=",", header=None, skiprows=1):
-            df.dropna(how='all', axis='columns', inplace=True)
-            df.columns = columns
-            errors, warnings = process_file_data(df, dataset, row_number)
-            error_logs = error_logs + errors
-            warning_logs = warning_logs + warnings
-            row_number = row_number + chunksize
+        csv_output = process_csv(dataset, dataset_file.document.name, chunksize)
+        error_logs = csv_output["error_logs"]
+        warning_logs = csv_output["warning_logs"]
+        columns = csv_output["columns"]
     else:
         logger.debug("Process as other filetype")
         skiprows = 1

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -14,7 +14,7 @@ from wazimap_ng.general.services.csv_helpers import csv_logger
 logger = logging.getLogger(__name__)
 
 def process_file_data(df, dataset, row_number):
-    df = df.applymap(lambda s:s.capitalize().strip() if type(s) == str else s)
+    df = df.applymap(lambda s:s.strip() if type(s) == str else s)
     datasource = (dict(d[1]) for d in df.iterrows())
     return loaddata(dataset, datasource, row_number)
 

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -21,7 +21,6 @@ def detect_encoding(filename):
             detector.feed(line)
             if detector.done: break
     detector.close()
-    print(detector.result)
     return detector.result
 
 def process_file_data(df, dataset, row_number):


### PR DESCRIPTION
## Description
Uploading a file with non-standard encodings used to break. This code fixes that by sniffing the encoding using chardet

## Related Issue
None

## How to test it locally
Create a csv file with a non standard encoding and upload it. Check that the upload doesn't break and that the correct data is loaded. E.g.

```
Geography,field1,field2,count
GEOCODE_1,‘F1_value_1,F2_value_1’,111),
GEOCODE_2,€ŠF1_value_2,F2_value_2®®,222),
```
## Changelog

### Added
Using chardet to detect the file encoding

### Updated

### Removed


## Checklist

- [X]  🚀 is the code ready to be merged and go live?
- [X]  🛠 does it work (build) locally

### Pull Request

- [X]  📰 good title
- [X]  📝good description
- [ ]  🔖 issue linked
- [X]  📖 changelog filled out

### Commits

- [X]  commits are clean
- [X]  commit messages are clean

### Code Quality

- [X]  🚧 no commented out code
- [X]  🖨 no unnecessary logging
- [X]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [X]  ✅ added (appropriate) unit tests
- [X]  💢 edge cases in tests were considered
- [X]  ✅ ran tests locally & are passing
