### PR TITLE
Fixed Profile Indicator Ordering

### DIFF
--- a/tests/datasets/factories.py
+++ b/tests/datasets/factories.py
@@ -25,6 +25,7 @@ class DatasetFactory(factory.django.DjangoModelFactory):
         model = models.Dataset
 
     geography_hierarchy = factory.SubFactory(GeographyHierarchyFactory)
+    groups = ["age group"]
 
 
 class UniverseFactory(factory.django.DjangoModelFactory):
@@ -40,6 +41,7 @@ class IndicatorFactory(factory.django.DjangoModelFactory):
 
     dataset = factory.SubFactory(DatasetFactory)
     universe = factory.SubFactory(UniverseFactory)
+    groups = factory.SelfAttribute('dataset.groups')
 
 
 class IndicatorDataFactory(factory.django.DjangoModelFactory):

--- a/tests/profile/factories.py
+++ b/tests/profile/factories.py
@@ -39,6 +39,7 @@ class ProfileIndicatorFactory(factory.django.DjangoModelFactory):
     subcategory = factory.SubFactory(IndicatorSubcategoryFactory)
     choropleth_method = factory.SubFactory(ChoroplethMethodFactory)
     subindicators = []
+    order = factory.Sequence(lambda n: n)
 
 
 class ProfileKeyMetricsFactory(factory.django.DjangoModelFactory):

--- a/tests/profile/serializers/test_indicator_data_serializer.py
+++ b/tests/profile/serializers/test_indicator_data_serializer.py
@@ -1,0 +1,61 @@
+import pytest
+
+from tests.profile.factories import ProfileFactory, ProfileIndicatorFactory
+from tests.datasets.factories import GeographyFactory, IndicatorDataFactory
+
+from wazimap_ng.profile.serializers.indicator_data_serializer import get_indicator_data
+
+@pytest.fixture
+def profile():
+    return ProfileFactory()
+
+@pytest.fixture
+def geography():
+    return GeographyFactory()
+
+
+@pytest.fixture
+def profile_indicators(profile):
+    pi1 = ProfileIndicatorFactory(profile=profile, label="PI1")
+    pi2 = ProfileIndicatorFactory(profile=profile, label="PI2")
+    return [
+        pi1, pi2
+    ]
+
+@pytest.fixture
+def indicator_data(geography, profile_indicators):
+    idata = []
+
+    for pi in profile_indicators:
+        indicator = pi.indicator
+        idatum = IndicatorDataFactory(geography=geography, indicator=indicator)
+        idata.append(idatum)
+
+
+    return idata
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("indicator_data")
+def test_profile_indicator_order(geography, profile_indicators):
+    profile = profile_indicators[0].profile
+    pi1, pi2 = profile_indicators
+
+    pi1.order = 1
+    pi1.save()
+
+    pi2.order = 2
+    pi2.save()
+
+    output = get_indicator_data(profile, geography)
+    assert output[0]["profile_indicator_label"] == "PI1"
+    assert output[1]["profile_indicator_label"] == "PI2"
+
+    pi1.order = 2
+    pi1.save()
+
+    pi2.order = 1
+    pi2.save()
+
+    output = get_indicator_data(profile, geography)
+    assert output[0]["profile_indicator_label"] == "PI2"
+    assert output[1]["profile_indicator_label"] == "PI1"

--- a/tests/profile/test_views.py
+++ b/tests/profile/test_views.py
@@ -12,16 +12,16 @@ class TestProfileGeographyData(APITestCase):
 
     def setUp(self):
         self.profile = ProfileFactory()
-        dataset = DatasetFactory(geography_hierarchy=self.profile.geography_hierarchy, groups=["age group", "gender"])
+        dataset = DatasetFactory(geography_hierarchy=self.profile.geography_hierarchy, groups=["age group", "gender"], profile=self.profile)
         indicator = IndicatorFactory(name="Age by Gender", dataset=dataset, groups=["gender"])
 
         category = IndicatorCategoryFactory(name="Category", profile=self.profile)
-        subcategory = IndicatorSubcategoryFactory(category=category, name="Subcategory")
-        ProfileIndicatorFactory(label="Indicator", profile=self.profile, indicator=indicator, subcategory=subcategory)
+        self.subcategory = IndicatorSubcategoryFactory(category=category, name="Subcategory")
+        ProfileIndicatorFactory(label="Indicator", profile=self.profile, indicator=indicator, subcategory=self.subcategory)
 
         GroupFactory(name="age group", dataset=dataset, subindicators=["15-19", "20-24"]),
         GroupFactory(name="gender", dataset=dataset, subindicators=["M", "F"]),
-        indicator_data_items_data = {
+        self.indicator_data_items_data = {
             "groups": {
                 "age group": {
                     "20-24": [
@@ -44,7 +44,7 @@ class TestProfileGeographyData(APITestCase):
                 },
             "subindicators": { "M": 52.34565, "F": 56.0179 }
             }
-        IndicatorDataFactory(indicator=indicator, geography=self.profile.geography_hierarchy.root_geography, data=indicator_data_items_data)
+        IndicatorDataFactory(indicator=indicator, geography=self.profile.geography_hierarchy.root_geography, data=self.indicator_data_items_data)
 
     def test_profile_geography_data_ordering_is_correct(self):
         expected_age_groups = OrderedDict([
@@ -76,4 +76,38 @@ class TestProfileGeographyData(APITestCase):
         age_group = groups.get('age group')
 
         assert age_group != wrong_order
+
+    def test_profile_geography_data_indicator_ordering_is_correct(self):
+        pi1 = ProfileIndicatorFactory(label="Indicator", order=2, profile=self.profile, subcategory=self.subcategory)
+        pi2 = ProfileIndicatorFactory(label="Indicator 2", order=1, profile=self.profile, subcategory=self.subcategory)
+
+        GroupFactory(name="age group", dataset=pi1.indicator.dataset, subindicators=["15-19", "20-24"]),
+        GroupFactory(name="gender", dataset=pi2.indicator.dataset, subindicators=["M", "F"]),
+
+        IndicatorDataFactory(indicator=pi1.indicator, geography=self.profile.geography_hierarchy.root_geography, data=self.indicator_data_items_data)
+        IndicatorDataFactory(indicator=pi2.indicator, geography=self.profile.geography_hierarchy.root_geography, data=self.indicator_data_items_data)
+
+        response = self.get('profile-geography-data', profile_id=self.profile.pk, geography_code=self.profile.geography_hierarchy.root_geography.code, extra={'format': 'json'})
+        indicators = response.data.get('profile_data').get('Category').get('subcategories').get('Subcategory').get('indicators')
+        indicator_list = list(indicators.items())
+
+        assert len(indicators) == 2
+        assert indicator_list[0][0] == 'Indicator 2'
+
+    def test_profile_geography_data_indicator_default_ordering_is_correct(self):
+        pi1 = ProfileIndicatorFactory(label="Indicator", profile=self.profile, subcategory=self.subcategory)
+        pi2 = ProfileIndicatorFactory(label="Indicator 2", profile=self.profile, subcategory=self.subcategory)
+
+        GroupFactory(name="age group", dataset=pi1.indicator.dataset, subindicators=["15-19", "20-24"]),
+        GroupFactory(name="gender", dataset=pi2.indicator.dataset, subindicators=["M", "F"]),
+
+        IndicatorDataFactory(indicator=pi1.indicator, geography=self.profile.geography_hierarchy.root_geography, data=self.indicator_data_items_data)
+        IndicatorDataFactory(indicator=pi2.indicator, geography=self.profile.geography_hierarchy.root_geography, data=self.indicator_data_items_data)
+
+        response = self.get('profile-geography-data', profile_id=self.profile.pk, geography_code=self.profile.geography_hierarchy.root_geography.code, extra={'format': 'json'})
+        indicators = response.data.get('profile_data').get('Category').get('subcategories').get('Subcategory').get('indicators')
+        indicator_list = list(indicators.items())
+
+        assert len(indicators) == 2
+        assert indicator_list[0][0] == 'Indicator'
 

--- a/wazimap_ng/profile/serializers/indicator_data_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer.py
@@ -31,7 +31,9 @@ def get_indicator_data(profile, geography):
             licence_url=F("indicator__dataset__metadata__licence__url"),
             licence_name=F("indicator__dataset__metadata__licence__name"),
             indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
-        ))
+        )
+        .order_by("indicator__profileindicator__order")
+    )
 
     return data
 


### PR DESCRIPTION

## Description
ProfileIndicator ordering stopped working a while back - the PR fixes the serializer to ensure that data is returned in the correct order

## Related Issue
None

## How to test it locally
Create two profile indicators. Set their order in the admin suite - check that they appear correctly in the frontend

## Changelog

### Added
Added tests and an order by clause in the query filter

### Updated

### Removed


## Checklist

- [X]  🚀 is the code ready to be merged and go live?
- [X]  🛠 does it work (build) locally

### Pull Request

- [X]  📰 good title
- [X]  📝good description
- [ ]  🔖 issue linked
- [X]  📖 changelog filled out

### Commits

- [X]  commits are clean
- [X]  commit messages are clean

### Code Quality

- [X]  🚧 no commented out code
- [X]  🖨 no unnecessary logging
- [X]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [X]  ✅ added (appropriate) unit tests
- []  💢 edge cases in tests were considered
- [X ]  ✅ ran tests locally & are passing
