### PR TITLE
Fixed file upload file encoding

### DIFF
--- a/tests/datasets/factories.py
+++ b/tests/datasets/factories.py
@@ -1,4 +1,5 @@
 import factory
+from factory.django import FileField
 
 from wazimap_ng.datasets import models
 
@@ -55,4 +56,11 @@ class GroupFactory(factory.django.DjangoModelFactory):
         model = models.Group
 
     dataset = factory.SubFactory(DatasetFactory)
+
+class DatasetFileFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = models.DatasetFile
+
+
+    document = factory.django.FileField()
 

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -19,14 +19,10 @@ def generate_file(data, encoding="utf8"):
     buffer.seek(0)
     return buffer
 
-def create_datasetfile(csv_data, encoding):
-    datasetfile = DatasetFileFactory()
-    buffer = generate_file(csv_data, encoding)
-    fp = datasetfile.document.open("wb")
-    fp.write(buffer.read())
-    fp.close()
 
-    return datasetfile
+def create_datasetfile(csv_data, encoding):
+    buffer = generate_file(csv_data, encoding)
+    return DatasetFileFactory(document__data=buffer.read())
 
 
 @pytest.fixture

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -80,8 +80,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     if ".csv" in filename:
         logger.debug(f"Processing as csv")
-        buffer = dataset_file.document.open("rb")
-        csv_output = process_csv(dataset, buffer, chunksize)
+        csv_output = process_csv(dataset, dataset_file.document.open("rb"), chunksize)
         error_logs = csv_output["error_logs"]
         warning_logs = csv_output["warning_logs"]
         columns = csv_output["columns"]

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -21,7 +21,7 @@ def detect_encoding(filename):
             detector.feed(line)
             if detector.done: break
     detector.close()
-    return detector.result
+    return detector.result["encoding"]
 
 def process_file_data(df, dataset, row_number):
     df = df.applymap(lambda s:s.strip() if type(s) == str else s)
@@ -29,8 +29,7 @@ def process_file_data(df, dataset, row_number):
     return loaddata(dataset, datasource, row_number)
 
 def process_csv(dataset, filename, chunksize=1000000):
-    encoding_guess = detect_encoding(filename)
-    encoding = encoding_guess["encoding"]
+    encoding = detect_encoding(filename)
     row_number = 1
     df = pd.read_csv(filename, nrows=1, dtype=str, sep=",", encoding=encoding)
     df.dropna(how='all', axis='columns', inplace=True)

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -21,7 +21,6 @@ def detect_encoding(filename):
             detector.feed(line)
             if detector.done: break
     detector.close()
-    print(detector.result)
     return detector.result
 
 def process_file_data(df, dataset, row_number):


### PR DESCRIPTION
## Description
Using the django storage backend mechanism instead of filesystem reads when files are uploaded.

## Related Issue

## How to test it locally
Change your storage backend from filesystem to something else such as s3 - upload a new dataset file.

## Changelog

### Added

### Updated

### Removed


## Checklist

- [X]  🚀 is the code ready to be merged and go live?
- [X]  🛠 does it work (build) locally

### Pull Request

- [X]  📰 good title
- [X]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [X]  commits are clean
- [X]  commit messages are clean

### Code Quality

- [X]  🚧 no commented out code
- [X]  🖨 no unnecessary logging
- [X]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [X]  ✅ added (appropriate) unit tests
- [X]  💢 edge cases in tests were considered
- [X]  ✅ ran tests locally & are passing
