### PR TITLE
Profile cache invalidation when linked geography hierarchies are updated #139

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -184,6 +184,29 @@ class TestCache(unittest.TestCase):
         ]
         mock_update_profile_cache.assert_has_calls(calls, any_order=True)
 
+        indicator = IndicatorFactory(dataset=group.dataset)
+        profile_indicator = ProfileIndicatorFactory(indicator=indicator)
+        key_metrics = ProfileKeyMetricsFactory(variable=indicator)
+        highlight = ProfileHighlightFactory(indicator=indicator)
+
+        assert group.dataset.profile != profile_indicator.profile
+        assert group.dataset.profile != key_metrics.profile
+        assert group.dataset.profile != highlight.profile
+
+        mock_update_profile_cache.reset_mock()
+
+        # update group
+        group.name = "changed"
+        group.save()
+        self.assertEqual(mock_update_profile_cache.call_count, 4)
+        calls = [
+            call(group.dataset.profile),
+            call(profile_indicator.profile),
+            call(key_metrics.profile),
+            call(highlight.profile),
+        ]
+        mock_update_profile_cache.assert_has_calls(calls, any_order=True)
+
     @patch('wazimap_ng.cache.update_profile_cache', autospec=True)
     def test_invalidate_profile_cache_for_geography_hierarchy_udpate(self, mock_update_profile_cache):
         mock_update_profile_cache.reset_mock()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -11,7 +11,10 @@ from tests.profile.factories import (
     ProfileIndicatorFactory, ProfileKeyMetricsFactory, ProfileHighlightFactory,
     ProfileFactory
 )
-from tests.datasets.factories import IndicatorFactory, GeographyFactory, DatasetDataFactory, GroupFactory
+from tests.datasets.factories import (
+    IndicatorFactory, GeographyFactory, DatasetDataFactory, GroupFactory,
+    GeographyHierarchyFactory, IndicatorDataFactory
+)
 
 from wazimap_ng import cache
 
@@ -168,9 +171,19 @@ class TestCache(unittest.TestCase):
         mock_update_profile_cache.reset_mock()
         geography = GeographyFactory()
         datasetdata = DatasetDataFactory(geography=geography)
-        self.assertEqual(mock_update_profile_cache.call_count, 1)
+        geography_hierarchy = GeographyHierarchyFactory(root_geography=geography)
+
+        # multiple profiles linked to same hierarchy
+        profile1 = ProfileFactory(geography_hierarchy=geography_hierarchy)
+        profile2 = ProfileFactory(geography_hierarchy=geography_hierarchy)
+        indicator_data = IndicatorDataFactory(geography=geography)
+
+        self.assertEqual(mock_update_profile_cache.call_count, 4)
         calls = [
             call(datasetdata.dataset.profile),
+            call(profile1),
+            call(profile2),
+            call(indicator_data.indicator.dataset.profile),
         ]
         mock_update_profile_cache.assert_has_calls(calls, any_order=True)
 

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -171,8 +171,6 @@ def geography_updated(sender, instance, **kwargs):
     hierarchy_profile_ids = list(instance.geographyhierarchy_set.values_list(
         "profile", flat=True
     ).order_by("profile").distinct())
-    print(hierarchy_profile_ids)
-
 
     profile_ids = set(dataset_data_profile_ids + indicator_data_profile_ids + hierarchy_profile_ids)
     for profile in Profile.objects.filter(id__in=set(profile_ids)):

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -9,7 +9,7 @@ from django.http import Http404
 from django.views.decorators.cache import cache_control
 from django.views.decorators.vary import vary_on_headers
 
-from wazimap_ng.datasets.models import Group, Geography, DatasetData
+from wazimap_ng.datasets.models import Group, Geography, DatasetData, GeographyHierarchy
 from wazimap_ng.points.models import Location, Category
 from wazimap_ng.profile.models import ProfileIndicator, ProfileHighlight, IndicatorCategory, IndicatorSubcategory, \
     ProfileKeyMetrics, Profile, Indicator
@@ -153,6 +153,13 @@ def geography_updated(sender, instance, **kwargs):
     ).order_by("dataset_id").distinct("dataset_id")
     for data in datasetdata_objs:
         update_profile_cache(data.dataset.profile)
+
+
+@receiver(post_save, sender=GeographyHierarchy)
+def geography_hierarchy_updated(sender, instance, **kwargs):
+
+    for profile in instance.profile_set.all():
+        update_profile_cache(profile)
 
 
 def cache_headers(func):


### PR DESCRIPTION
## Description
Invalidate cache for profile when linked geography hierarchy is updated.

## Related Issue
#139 

## How to test it locally
save geography hierarchy from admin panel and api should load hierarchy changes.
I checked if dev server logs updated.

## Changelog
* Added invalidate cache signal for geography hierarchy in cache.py
* Added test for change above

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
