### PR TITLE
Added unit tests for profile indicator admin

### DIFF
--- a/tests/profile/admin/admins/test_profile_indicator_admin.py
+++ b/tests/profile/admin/admins/test_profile_indicator_admin.py
@@ -1,0 +1,39 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from tests.profile.factories import ProfileIndicatorFactory
+
+from wazimap_ng.profile.models import ProfileIndicator 
+from wazimap_ng.profile.admin import ProfileIndicatorAdmin
+
+@pytest.fixture
+def profile_indicator_admin():
+    return ProfileIndicatorAdmin(model=ProfileIndicator, admin_site=AdminSite())
+
+@pytest.mark.django_db
+class TestProfileIndicatorAdmin:
+    def test_save(self, profile_indicator_admin):
+        pi = ProfileIndicatorFactory()
+        pi2 = ProfileIndicator()
+
+        pi2.profile = pi.profile
+        pi2.indicator = pi.indicator
+        pi2.subcategory = pi.subcategory
+        pi2.choropleth_method = pi.choropleth_method
+        pi2.order = pi.order
+
+        assert pi2.pk is None
+        assert ProfileIndicator.objects.count() == 1
+
+        profile_indicator_admin.save_model(obj=pi2, form=None, change=False, request=None)
+
+        assert pi2.pk is not None
+        assert ProfileIndicator.objects.count() == 2
+
+    def test_update(self, profile_indicator_admin):
+        pi = ProfileIndicatorFactory()
+        pi.label = "Test label"
+        profile_indicator_admin.save_model(obj=pi, form=None, change=True, request=None)
+
+        assert ProfileIndicator.objects.get(pk=pi.pk).label == "Test label"
+
+


### PR DESCRIPTION
## Description
Preparing to remove the sorting widget in the ProfileIndicatorAdmin. Removing the widget is simple but we need to figure out what to do with the existing sorting machinery

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
