### PR TITLE
Removed subindicator field from profile indicator admin view #150

### DIFF
--- a/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
@@ -40,9 +40,6 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel):
         ("Profile fields", {
           'fields': ('label', 'subcategory', 'description', 'choropleth_method')
         }),
-        ("Subindicators", {
-          'fields': ('subindicators',)
-        }),
         ("Charts", {
           'fields': ('chart_configuration',)
         })

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -1,7 +1,7 @@
 from django import forms
 
 from ... import models
-from wazimap_ng.general.widgets import VariableFilterWidget, SortableWidget
+from wazimap_ng.general.widgets import VariableFilterWidget
 from django_json_widget.widgets import JSONEditorWidget
 
 class ProfileIndicatorAdminForm(forms.ModelForm):
@@ -10,14 +10,6 @@ class ProfileIndicatorAdminForm(forms.ModelForm):
         fields = '__all__'
         widgets = {
             'indicator': VariableFilterWidget,
-            'subindicators': SortableWidget,
             'chart_configuration': JSONEditorWidget,
 
         }
-
-    def clean_subindicators(self):
-        if self.instance.pk:
-            values = self.instance.indicator.subindicators
-            order = self.cleaned_data['subindicators']
-            return [values[i] for i in order] if order else values
-        return []


### PR DESCRIPTION

## Description
Changed widget of subindicators in profile indicator admin to JsonEditor widget.
Now it looks like this: 

<img width="1722" alt="Screenshot 2020-11-04 at 4 37 18 PM" src="https://user-images.githubusercontent.com/6871866/98104137-0dd9e200-1ebc-11eb-91da-1cc1328426e1.png">


Update: Removed the field form admin view after review

## Related Issue
#150 

## How to test it locally

Visit to profile indicator admin page and check subindicators section not present

## Changelog

Removed clean subindicator method
Removed field from admin view

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
