### PR TITLE
Correct bug for filtering profile categories by theme

### DIFF
--- a/wazimap_ng/general/admin/filters.py
+++ b/wazimap_ng/general/admin/filters.py
@@ -55,6 +55,20 @@ class SubCategoryFilter(DynamicBaseFilter):
     model_class = IndicatorSubcategory
 
 
+class ThemeFilter(DynamicBaseFilter):
+    title = "Theme"
+    parameter_name = 'theme_id'
+    model_class = Theme
+
+    def lookups(self, request, model_admin):
+        profiles = permissions.get_objects_for_user(
+            request.user, Profile, include_public=True
+        )
+        return [(theme.id, theme) for theme in self.model_class.objects.filter(
+            profile__in=profiles
+        )]
+
+
 # Datasets App Filters
 class GeographyHierarchyFilter(DynamicBaseFilter):
     title = 'Geography Hierarchy'
@@ -86,20 +100,6 @@ class IndicatorFilter(DynamicBaseFilter):
     parameter_name = 'indicator__id'
     model_class = Indicator
 
-
-# Points app
-class ThemeFilter(DynamicBaseFilter):
-    title = "Theme"
-    parameter_name = 'profilecategory__theme_id'
-    model_class = Theme
-
-    def lookups(self, request, model_admin):
-        profiles = permissions.get_objects_for_user(
-            request.user, Profile, include_public=True
-        )
-        return [(theme.id, theme) for theme in self.model_class.objects.filter(
-            profile__in=profiles
-        )]
 
 class CollectionFilter(DynamicBaseFilter):
     title = 'Collection'


### PR DESCRIPTION
## Description
This PR corrects the bug that occurs when you try to filter profile collections in the admin panel by a theme.

```bash
FieldError: Cannot resolve keyword 'profilecategory' into field. Choices are: category, category_id, created, description, icon, id, label, profile, profile_id, theme, theme_id, updated
(16 additional frame(s) were not displayed)
...
  File "django/db/models/sql/query.py", line 1290, in add_q
    clause, _ = self._add_q(q_object, self.used_aliases)
  File "django/db/models/sql/query.py", line 1318, in _add_q
    split_subq=split_subq, simple_col=simple_col,
  File "django/db/models/sql/query.py", line 1190, in build_filter
    lookups, parts, reffed_expression = self.solve_lookup_type(arg)
  File "django/db/models/sql/query.py", line 1049, in solve_lookup_type
    _, field, _, lookup_parts = self.names_to_path(lookup_splitted, self.get_meta())
  File "django/db/models/sql/query.py", line 1420, in names_to_path
    "Choices are: %s" % (name, ", ".join(available)))
```

I have a question related to Black. When I run it, it changes almost all Python files. What should I do, @milafrerichs  ? I think it would be better to create a pre-commit yaml which checks it each time when we try to push a commit.

## Related Issue
Fixes #156 

## How to test it locally

## Changelog

### Added

### Updated
ThemeFilter's parameter_name is updated.

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
