### PR TITLE
profile indicator subcategory dropdown filtering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,9 @@ venv.bak/
 staticfiles
 .DS_Store
 
+# IDE
+.idea
+
 data/
 
 wazimap-ng.sublime-project

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -3,7 +3,7 @@
         const $profileEl = $(document).find("#id_profile");
         const $subcategoryEl = $(document).find("#id_subcategory");
 
-        $(document).find("#id_profile").on('change', function (e) {
+        $profileEl.on('change', function (e) {
             // trigger "loadSubcategory" func only when it was manually changed
             if (e.originalEvent !== undefined) {
                 // load subcategories based on selected profile

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -2,6 +2,7 @@
     jQuery(document).ready(function ($) {
         const $profileEl = $(document).find("#id_profile");
         const $subcategoryEl = $(document).find("#id_subcategory");
+        const $emptyOptionEl = $("<option></option>");
 
         $profileEl.on('change', function (e) {
             // trigger "loadSubcategory" func only when it was manually changed
@@ -11,13 +12,16 @@
             }
         });
 
+        function appendOptionEl($outerEl, val, text){
+            $outerEl.append($emptyOptionEl.clone().attr("value", val).text(text));
+        }
+
         function clearSubcategories() {
             $subcategoryEl.empty();
-            $subcategoryEl.append($("<option></option>").attr("value", "").text("----------"));
+            appendOptionEl($subcategoryEl, "", "-----------")
         }
 
         function loadSubcategory(selectedProfile) {
-            console.log("selectedProfile", selectedProfile)
             if (selectedProfile) {
                 var url = `/api/v1/profiles/${selectedProfile}/subcategories/`;
                 $.ajax({
@@ -26,7 +30,7 @@
                         // clear it here to avoid "select" input flickering which appears during AJAX call
                         clearSubcategories();
                         $.each(data, function (key, value) {
-                            $subcategoryEl.append($("<option></option>").attr("value", value.id).text(value.name));
+                            appendOptionEl($subcategoryEl, value.id, value.name)
                         });
                     }
                 })

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -1,11 +1,14 @@
 (function ($) {
     jQuery(document).ready(function ($) {
-        const $profileEl = $("#id_profile");
-        const $subcategoryEl = $("#id_subcategory");
+        const $profileEl = $(document).find("#id_profile");
+        const $subcategoryEl = $(document).find("#id_subcategory");
 
-        $profileEl.on('change', function (e) {
-            // load subcategories based on selected profile
-            loadSubcategory(e.target.value);
+        $(document).find("#id_profile").on('change', function (e) {
+            // trigger "loadSubcategory" func only when it was manually changed
+            if (e.originalEvent !== undefined) {
+                // load subcategories based on selected profile
+                loadSubcategory(e.target.value);
+            }
         });
 
         function clearSubcategories() {
@@ -14,11 +17,13 @@
         }
 
         function loadSubcategory(selectedProfile) {
+            console.log("selectedProfile", selectedProfile)
             if (selectedProfile) {
                 var url = `/api/v1/profiles/${selectedProfile}/subcategories/`;
                 $.ajax({
                     url: url,
                     success: function (data) {
+                        // clear it here to avoid "select" input flickering which appears during AJAX call
                         clearSubcategories();
                         $.each(data, function (key, value) {
                             $subcategoryEl.append($("<option></option>").attr("value", value.id).text(value.name));

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -1,0 +1,34 @@
+(function ($) {
+    jQuery(document).ready(function ($) {
+        const $profileEl = $("#id_profile");
+        const $subcategoryEl = $("#id_subcategory");
+
+        $profileEl.on('change', function (e) {
+            // load subcategories based on selected profile
+            loadSubcategory(e.target.value);
+        });
+
+        function clearSubcategories() {
+            $subcategoryEl.empty();
+            $subcategoryEl.append($("<option></option>").attr("value", "").text("----------"));
+        }
+
+        function loadSubcategory(selectedProfile) {
+            if (selectedProfile) {
+                var url = `/api/v1/profiles/${selectedProfile}/subcategories/`;
+                $.ajax({
+                    url: url,
+                    success: function (data) {
+                        clearSubcategories();
+                        $.each(data, function (key, value) {
+                            $subcategoryEl.append($("<option></option>").attr("value", value.id).text(value.name));
+                        });
+                    }
+                })
+            } else {
+                clearSubcategories();
+            }
+        }
+    });
+})(django.jQuery);
+

--- a/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
@@ -50,6 +50,9 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel):
 
     help_texts = ["choropleth_method", ]
 
+    class Media:
+        js = ("/static/js/profile-indicator-admin.js",)
+
     def get_readonly_fields(self, request, obj=None):
         if obj: # editing an existing object
             return ("profile",) + self.readonly_fields

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -1,15 +1,24 @@
 from django import forms
 
-from ... import models
 from wazimap_ng.general.widgets import VariableFilterWidget
 from django_json_widget.widgets import JSONEditorWidget
 
+from ...models import IndicatorSubcategory, ProfileIndicator
+
+
 class ProfileIndicatorAdminForm(forms.ModelForm):
     class Meta:
-        model = models.ProfileIndicator
+        model = ProfileIndicator
         fields = '__all__'
         widgets = {
             'indicator': VariableFilterWidget,
             'chart_configuration': JSONEditorWidget,
 
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # do not load any subcategories by default,
+        # it should be loaded based on selected profile via JS
+        self.fields['subcategory'].queryset = IndicatorSubcategory.objects.none()

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -1,14 +1,15 @@
 from django import forms
+from django.core.exceptions import ValidationError
 
 from wazimap_ng.general.widgets import VariableFilterWidget
 from django_json_widget.widgets import JSONEditorWidget
 
-from ...models import IndicatorSubcategory, ProfileIndicator
+from ... import models
 
 
 class ProfileIndicatorAdminForm(forms.ModelForm):
     class Meta:
-        model = ProfileIndicator
+        model = models.ProfileIndicator
         fields = '__all__'
         widgets = {
             'indicator': VariableFilterWidget,
@@ -19,6 +20,28 @@ class ProfileIndicatorAdminForm(forms.ModelForm):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-        # do not load any subcategories by default,
+        # do not show any subcategories by default,
         # it should be loaded based on selected profile via JS
-        self.fields['subcategory'].queryset = IndicatorSubcategory.objects.none()
+        self.fields['subcategory'].choices = [["", "-----------"]]
+
+        # filter subcategories by profile if initial data provided
+        if self.data.get('profile'):
+            subcategories = models.IndicatorSubcategory.objects.filter(
+                category__profile_id=self.data['profile']
+            )
+            self.fields['subcategory'].choices += [
+                [obj.id, obj.name] for obj in subcategories
+            ]
+
+
+
+    def clean_subcategory(self):
+        subcategory = self.cleaned_data['subcategory']
+        profile = self.cleaned_data['profile']
+
+        # do not allow to save subcategory which not related to the selected profile
+        if subcategory.category.profile != profile:
+            msg = f'This subcategory cannot be selected with {profile} profile.'
+            raise ValidationError(msg)
+
+        return subcategory

--- a/wazimap_ng/profile/views.py
+++ b/wazimap_ng/profile/views.py
@@ -78,7 +78,9 @@ class ProfileCategoriesList(generics.ListAPIView):
         serializer = self.get_serializer_class()(queryset, many=True)
         return Response(serializer.data)
 
-class ProfileSubcategoriesList(generics.ListAPIView):
+class ProfileSubcategoriesByCategoryList(generics.ListAPIView):
+    """Load subcategories for specific profile and category"""
+
     queryset = models.IndicatorSubcategory.objects.all()
     serializer_class = serializers.IndicatorSubcategorySerializer
 
@@ -86,6 +88,20 @@ class ProfileSubcategoriesList(generics.ListAPIView):
         profile = get_object_or_404(models.Profile, pk=profile_id)
         category = get_object_or_404(models.IndicatorCategory, pk=category_id)
         queryset = self.get_queryset().filter(category__profile=profile, category=category)
+
+        serializer = self.get_serializer_class()(queryset, many=True)
+        return Response(serializer.data)
+
+
+class ProfileSubcategoriesList(generics.ListAPIView):
+    """Load subcategories for specific profile"""
+
+    queryset = models.IndicatorSubcategory.objects.all()
+    serializer_class = serializers.IndicatorSubcategorySerializer
+
+    def get(self, request, profile_id):
+        profile = get_object_or_404(models.Profile, pk=profile_id)
+        queryset = self.get_queryset().filter(category__profile=profile)
 
         serializer = self.get_serializer_class()(queryset, many=True)
         return Response(serializer.data)

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -74,8 +74,13 @@ urlpatterns = [
     ),
     path(
         "api/v1/profiles/<int:profile_id>/categories/<int:category_id>/",
-        cache(profile_views.ProfileSubcategoriesList.as_view()),
+        cache(profile_views.ProfileSubcategoriesByCategoryList.as_view()),
         name="profile-subcategories",
+    ),
+    path(
+        "api/v1/profiles/<int:profile_id>/subcategories/",
+        cache(profile_views.ProfileSubcategoriesList.as_view()),
+        name="profile-subcategories-list",
     ),
     path(
         "api/v1/profiles/<int:profile_id>/geographies/<str:geography_code>/",


### PR DESCRIPTION
## Description
When creating a new ProfileIndicator, the subcategory dropdown does not filter options related to the selected profile - currently, subcategories from all profiles are display

## Related Issue
https://github.com/OpenUpSA/wazimap-ng/issues/157

## How to test it locally
Pre-conditions:

- different profiles available
- multiple subcategories assigned to different profiles (through categories)

To test:
1. Open "Add profile indicator" page (http://localhost:8000/admin/profile/profileindicator/add/)
2. Select different profiles from the dropdown list
3. Check available subcategories for each profile

## Changelog

### Added
1. New endpoint to get the list of all subcategories related to specific profile - `/api/v1/profiles/{id}/subcategories/`
2. `profile-indicator-admin.js` file with logic to fetch subcategories on profile select

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
