### PR TITLE
Point collection permissions fix for profile accounts

### DIFF
--- a/tests/points/admin/test_profile_category_admin.py
+++ b/tests/points/admin/test_profile_category_admin.py
@@ -1,7 +1,6 @@
 import pytest
 
 from django.contrib.admin.sites import AdminSite
-from django.contrib.auth.models import Group
 from django.urls import reverse
 
 from wazimap_ng.config.common import PERMISSION_TYPES
@@ -9,7 +8,7 @@ from wazimap_ng.general.services.permissions import assign_perms_to_group
 from wazimap_ng.points.models import ProfileCategory
 from wazimap_ng.points.admin import ProfileCategoryAdmin
 
-from tests.points.factories import ProfileCategoryFactory, UserFactory
+from tests.points.factories import ProfileCategoryFactory, UserFactory, AuthGroupFactory
 
 
 @pytest.fixture
@@ -30,7 +29,7 @@ def staff_user():
 
 @pytest.fixture
 def profile_group(test_private_profile_category):
-    profile_group = Group.objects.create(
+    profile_group = AuthGroupFactory(
         name=test_private_profile_category.profile.name
     )
     assign_perms_to_group(

--- a/tests/points/admin/test_profile_category_admin.py
+++ b/tests/points/admin/test_profile_category_admin.py
@@ -1,24 +1,72 @@
 import pytest
 
 from django.contrib.admin.sites import AdminSite
+from django.contrib.auth.models import Group
+from django.urls import reverse
 
+from wazimap_ng.config.common import PERMISSION_TYPES
+from wazimap_ng.general.services.permissions import assign_perms_to_group
 from wazimap_ng.points.models import ProfileCategory
 from wazimap_ng.points.admin import ProfileCategoryAdmin
 
-from tests.points.factories import ProfileCategoryFactory
+from tests.points.factories import ProfileCategoryFactory, UserFactory
 
-@pytest.fixture()
-def test_profile_category():
-    return ProfileCategoryFactory()
 
-from django.urls import reverse
-def test_changelist_view(admin_user, rf, test_profile_category):
+@pytest.fixture
+def test_private_profile_category(db):
+    return ProfileCategoryFactory(
+        profile__permission_type=PERMISSION_TYPES[0][0],
+    )
+
+@pytest.fixture
+def test_profile_category(db):
+    return ProfileCategoryFactory(
+        profile__permission_type=PERMISSION_TYPES[1][0],
+    )
+
+@pytest.fixture
+def staff_user():
+    return UserFactory(is_staff=True)
+
+@pytest.fixture
+def profile_group(test_private_profile_category):
+    profile_group = Group.objects.create(
+        name=test_private_profile_category.profile.name
+    )
+    assign_perms_to_group(
+        test_private_profile_category.profile.name, test_private_profile_category.profile
+    )
+    return profile_group
+
+def test_changelist_view(rf, test_profile_category, staff_user):
     url = reverse("admin:points_profilecategory_changelist")
     request = rf.get(url)
-    request.user = admin_user
-    print(admin_user.__dict__)
+    request.user = staff_user
+
     pc_admin = ProfileCategoryAdmin(model=ProfileCategory, admin_site=AdminSite())
 
-    print(pc_admin.get_queryset(request))
-    # location_form = location_admin.get_form(request)
-    assert 2 == 1
+    requested_qs = pc_admin.get_queryset(request)
+
+    # verify staff_user has access to ProfileCategory with public access
+    assert test_profile_category in list(requested_qs)
+
+
+def test_changelist_view_with_private_profile(
+        rf, test_private_profile_category, staff_user, profile_group
+):
+    url = reverse("admin:points_profilecategory_changelist")
+    request = rf.get(url)
+    request.user = staff_user
+    pc_admin = ProfileCategoryAdmin(model=ProfileCategory, admin_site=AdminSite())
+    requested_qs = pc_admin.get_queryset(request)
+
+    # make sure `test_profile_category` is not in `Profile Collections`
+    # as staff_user has no access to needed profile yet
+    assert test_private_profile_category not in list(requested_qs)
+
+    staff_user.groups.add(profile_group)
+    requested_qs = pc_admin.get_queryset(request)
+
+    # verify that staff_user now can see `test_profile_category`
+    # once he added to profile group
+    assert test_private_profile_category in list(requested_qs)

--- a/tests/points/admin/test_profile_category_admin.py
+++ b/tests/points/admin/test_profile_category_admin.py
@@ -1,0 +1,24 @@
+import pytest
+
+from django.contrib.admin.sites import AdminSite
+
+from wazimap_ng.points.models import ProfileCategory
+from wazimap_ng.points.admin import ProfileCategoryAdmin
+
+from tests.points.factories import ProfileCategoryFactory
+
+@pytest.fixture()
+def test_profile_category():
+    return ProfileCategoryFactory()
+
+from django.urls import reverse
+def test_changelist_view(admin_user, rf, test_profile_category):
+    url = reverse("admin:points_profilecategory_changelist")
+    request = rf.get(url)
+    request.user = admin_user
+    print(admin_user.__dict__)
+    pc_admin = ProfileCategoryAdmin(model=ProfileCategory, admin_site=AdminSite())
+
+    print(pc_admin.get_queryset(request))
+    # location_form = location_admin.get_form(request)
+    assert 2 == 1

--- a/tests/points/factories.py
+++ b/tests/points/factories.py
@@ -1,4 +1,5 @@
 import factory
+from django.contrib.auth import get_user_model
 
 from django.contrib.gis.geos import Point
 
@@ -40,3 +41,11 @@ class LocationFactory(factory.django.DjangoModelFactory):
     name = "Location"
     coordinates = Point(1.0, 1.0)
     data = {}
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = get_user_model()
+
+    username = factory.Sequence(lambda n: 'manager_%s' % n)
+    email = factory.LazyAttribute(lambda o: '%s@example.org' % o.username)

--- a/tests/points/factories.py
+++ b/tests/points/factories.py
@@ -1,5 +1,5 @@
 import factory
-from django.contrib.auth import get_user_model
+from django.contrib.auth import get_user_model, models as auth_models
 
 from django.contrib.gis.geos import Point
 
@@ -49,3 +49,8 @@ class UserFactory(factory.django.DjangoModelFactory):
 
     username = factory.Sequence(lambda n: 'manager_%s' % n)
     email = factory.LazyAttribute(lambda o: '%s@example.org' % o.username)
+
+
+class AuthGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.Group

--- a/wazimap_ng/general/services/custom_permissions/queryset_filters.py
+++ b/wazimap_ng/general/services/custom_permissions/queryset_filters.py
@@ -72,7 +72,6 @@ class CustomQuerySet(models.QuerySet):
 	# Points
 	def get_points_category_queryset(self, user):
 		profiles = permissions.get_objects_for_user(user, Profile)
-
 		return permissions.get_objects_for_user(
 			user, Category, queryset=self.filter(profile__in=profiles)
 		)
@@ -97,6 +96,4 @@ class CustomQuerySet(models.QuerySet):
 		profiles = permissions.get_objects_for_user(
 		    user, Profile
 		)
-		return permissions.get_objects_for_user(
-		    user, ProfileCategory
-		).filter(profile__in=profiles)
+		return self.filter(profile__in=profiles)


### PR DESCRIPTION
## Description

A user doesn't see point collections for either profile she is associated with including the new collection she just created. My superadmin account does - suspect a permission issue somewhere

## Related Issue
https://github.com/OpenUpSA/wazimap-ng/issues/152

NOTE: Current PR should replace https://github.com/OpenUpSA/wazimap-ng/pull/160

## How to test it locally
Test case 1 (Private Profile):
Pre-conditions:
 - Private Profile is created
 - Points Collections associated with Private Profile (created earlier) is created

  1. Log in as a regular staff user with `points` permissions
  2. Log in as admin user with full access in different browser
  3. Make sure staff user has access to `Points -> Profile Collections` and it is empty
  4. As an admin user assign staff user to Private Profile group
  5. As a staff user open `Points -> Profile Collections` and make sure Collection associated with Private profile is there

Test case 2 (Public Profile):
Pre-conditions:
 - Public Profile is created
 - Points Collections associated with Public Profile (created earlier) is created

  1. Log in as a regular staff user with `points` permissions
  2. Log in as admin user with full access in different browser
  3. Make sure staff user has access to `Points -> Profile Collections` and verify Collection associated with Public profile is there

NOTE: not sure if test case 2 is correct, let me know if it should be changed.

## Changelog

### Added

 - tests for Points -> Profile Collections

### Updated
 - `get_points_profilecategory_queryset` function

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
