### PR TITLE
Extended cache invalidation for Location, Profile Category, and Theme updates

### DIFF
--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -146,6 +146,18 @@ def subindicator_group_update(sender, instance, **kwargs):
         update_profile_cache(profile_obj)
 
 
+@receiver(post_save, sender=ProfileCategory)
+def profile_category_updated(sender, instance, **kwargs):
+    profile_category_id = instance.id
+    profiles_to_invalidate_cache = Profile.objects.filter(
+        Q(theme__profile_categories__category_id=profile_category_id)
+        | Q(category__profilecategory__id=profile_category_id)
+        | Q(profilecategory__id=profile_category_id)
+    ).distinct()
+    for profile_obj in profiles_to_invalidate_cache:
+        update_profile_cache(profile_obj)
+
+
 @receiver(post_save, sender=Location)
 def point_updated_location(sender, instance, **kwargs):
     update_point_cache(instance.category)
@@ -154,11 +166,6 @@ def point_updated_location(sender, instance, **kwargs):
 @receiver(post_save, sender=Category)
 def point_updated_category(sender, instance, **kwargs):
     update_point_cache(instance)
-
-
-@receiver(post_save, sender=ProfileCategory)
-def point_updated_profile_category(sender, instance, **kwargs):
-    update_point_cache(instance.category)
 
 
 @receiver(post_save, sender=Theme)


### PR DESCRIPTION
## Description
I checked the database schema first and created a query for related tables of `points_profilecategory`. That's how it looks like in my local DB instance:
<img width="1202" alt="image" src="https://user-images.githubusercontent.com/41292272/99888072-c349bb00-2c5a-11eb-8757-c0dc5b4e80f6.png">
and that's how my query looks like: 
https://github.com/OpenUpSA/wazimap-ng/blob/7d4984e3cf258887b7d80bef538c005f357897a2/wazimap_ng/cache.py#L149-L158

I hope I understood the concept correctly. Because I didn't have a chance to test it on frontend-side. I installed wazimap-ng-ui and it's running fine but I couldn't see anything on the map. I think my dummy objects didn't work well.
## Related Issue
Fixes #164 
## How to test it locally
When docker-compose is running, this command will run the new tests:
`docker-compose exec -e DJANGO_CONFIGURATION=Test web pytest /app/tests/test_cache.py::TestCache::test_invalidate_profile_cache_for_profile_category_update`
## Changelog

### Added
- Two more functions to cache.py which receives post_save signals for `ProfileCategory` and `Theme` (There are already for `Location`).
- Test that checks if `update_cache` method called as expected or not.
### Updated
- There were some typos and code styling errors. I fixed them.
### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
