### PR TITLE
Update get_document() methods to extract files with correct extensions

### DIFF
--- a/wazimap_ng/datasets/admin/dataset_file_admin.py
+++ b/wazimap_ng/datasets/admin/dataset_file_admin.py
@@ -1,3 +1,4 @@
+import os
 import pandas as pd
 
 from .. import models
@@ -38,9 +39,11 @@ class CustomGeographyHierarchyFilter(filters.GeographyHierarchyFilter):
     def queryset(self, request, queryset):
         return filter_custom_queryset(self, request, queryset)
 
+
 class CustomProfileFilter(filters.ProfileFilter):
     def queryset(self, request, queryset):
         return filter_custom_queryset(self, request, queryset)
+
 
 class CustomMetadataFilter(filters.DatasetMetaDataFilter):
     def queryset(self, request, queryset):
@@ -84,8 +87,8 @@ class DatasetFileAdmin(BaseAdminModel):
     get_dataset_name.short_description = 'Dataset'
 
     def get_document(self, obj):
-        file_extension = obj.document.name.split(".")[-1]
-        doc_name = f'{obj.name}-{obj.id}.{file_extension}'
+        _, file_extension = os.path.splitext(obj.document.name)
+        doc_name = f'{obj.name}-{obj.id}{file_extension}'
         return mark_safe(
             f'<a href="{obj.document.url}" download="{doc_name}">{doc_name}</a>'
         )

--- a/wazimap_ng/points/admin/coordinate_file_admin.py
+++ b/wazimap_ng/points/admin/coordinate_file_admin.py
@@ -1,14 +1,14 @@
+import os
 import pandas as pd
 
 from .. import models
 from django.contrib import admin
 from django.urls import reverse
-from django.conf import settings
 from django.utils.safestring import mark_safe
 from django.template.loader import render_to_string
 
 from wazimap_ng.general.admin.admin_base import BaseAdminModel
-from wazimap_ng.datasets import hooks
+
 
 @admin.register(models.CoordinateFile)
 class CoordinateFileAdmin(BaseAdminModel):
@@ -29,8 +29,10 @@ class CoordinateFileAdmin(BaseAdminModel):
     )
 
     def get_document(self, obj):
+        _, file_extension = os.path.splitext(obj.document.name)
+        doc_name = f'{obj.name}-{obj.id}{file_extension}'
         return mark_safe(
-            f'<a href="{obj.document.url}" download="{obj.name}-{obj.id}.csv">{obj.name}-{obj.id}.csv</a>'
+            f'<a href="{obj.document.url}" download="{doc_name}">{doc_name}</a>'
         )
     get_document.short_description = 'Document'
 


### PR DESCRIPTION
## Description
I thought it's safer to use [os.path's splittext()](https://docs.python.org/3/library/os.path.html#os.path.splitext) for extracting file extensions. So, I changed the code for that. Then, I changed CoordinateFile's `get_document()` method which was extracting all files with `.csv` extension. 

Yet, I'm still suspecting that this issue might be because of the frontend side.

**Note:** I opened a PR in `wazimap-ng-ui`, which should solve this issue: https://github.com/OpenUpSA/wazimap-ng-ui/pull/170. But this PR is needed because it has some changes for coordinate files.

## Related Issue
#125
## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
