### PR TITLE
Improved the 404 not found error message on profile-by-url

### DIFF
--- a/wazimap_ng/profile/views.py
+++ b/wazimap_ng/profile/views.py
@@ -12,6 +12,7 @@ from django.views.decorators.cache import never_cache
 from rest_framework import generics
 from rest_framework.response import Response
 from rest_framework.decorators import api_view
+from rest_framework.exceptions import NotFound
 
 
 from . import models
@@ -51,7 +52,7 @@ class ProfileByUrl(generics.RetrieveAPIView):
         qs = qs.filter(configuration__urls__contains=[hostname])
         if qs.count() == 0:
             logger.warning(f"Can't find a profile for {hostname} - returning 404 ")
-            raise Http404
+            raise NotFound(detail=f"Could not find matching profile with hostname: {hostname}. Check your profile configuration to ensure that it contains {hostname} in the urls array.")
 
         instance = qs.first()
         serializer = self.get_serializer(instance)


### PR DESCRIPTION
## Description
The previous error message given when the wm-hostname was missing did not provide much information

## Related Issue
N/A

## How to test it locally
http://localhost:8000/api/v1/profile_by_url/?format=json

should return a 404 with a friendlier message

## Changelog

### Added

### Updated

### Removed


## Checklist

- [X]  🚀 is the code ready to be merged and go live?
- [X]  🛠 does it work (build) locally

### Pull Request

- [X]  📰 good title
- [X]  📝good description
- []  🔖 issue linked
- []  📖 changelog filled out

### Commits

- [X]  commits are clean
- [X]  commit messages are clean

### Code Quality

- [X]  🚧 no commented out code
- [X]  🖨 no unnecessary logging
- [X]  🎱 no magic numbers
- []  black was run locally (as part of the pre-commit hook)

### Testing

- [X]  ✅ added (appropriate) unit tests
- [X]  💢 edge cases in tests were considered
- [X]  ✅ ran tests locally & are passing
