### PR TITLE
Add icon field in profile collection api #190

### DIFF
--- a/wazimap_ng/points/views.py
+++ b/wazimap_ng/points/views.py
@@ -109,12 +109,17 @@ def boundary_point_count_helper(profile, geography):
             theme_dict[id] = theme
             res.append(theme)
         theme = theme_dict[id]
+
+        pc_icon = lc["category__profilecategory__icon"]
+        if not pc_icon or pc_icon == "None":
+            pc_icon = ""
+
         theme["subthemes"].append({
             "label": lc["category__profilecategory__label"],
             "id": lc["category__profilecategory__id"],
             "count": lc["count_category"],
             "color": lc["category__profilecategory__color"],
-            "icon": lc["category__profilecategory__icon"],
+            "icon": pc_icon,
             "metadata": {
                 "source": lc["category__metadata__source"],
                 "description": lc["category__metadata__description"],

--- a/wazimap_ng/points/views.py
+++ b/wazimap_ng/points/views.py
@@ -83,6 +83,7 @@ def boundary_point_count_helper(profile, geography):
             .values(
                 "category__profilecategory__id", "category__profilecategory__label",
                 "category__profilecategory__color",
+                "category__profilecategory__icon",
                 "category__profilecategory__theme__name",
                 "category__profilecategory__theme__icon",
                 "category__profilecategory__theme__id",
@@ -113,6 +114,7 @@ def boundary_point_count_helper(profile, geography):
             "id": lc["category__profilecategory__id"],
             "count": lc["count_category"],
             "color": lc["category__profilecategory__color"],
+            "icon": lc["category__profilecategory__icon"],
             "metadata": {
                 "source": lc["category__metadata__source"],
                 "description": lc["category__metadata__description"],


### PR DESCRIPTION
## Description
Add icon field to the profile collection api.
Icon field is present in models but not included in views for all_detail api endpoint.

## Related Issue

#190 

## How to test it locally
To test it locally check api endpoint:
`http://localhost:8000/api/v1/all_details/profile/<profile_id>/geography/<geo_code>/?format=json`

Subthemes inside themes should have new field named icon.
It will be "None" if there is no icon else will have icon value

## Changelog
Added icon field in response of all_detail api endpoint.

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
