### PR TITLE
Fix ordering issue for themes and sub themes in all_detail api endpoint

### DIFF
--- a/tests/general/test_views.py
+++ b/tests/general/test_views.py
@@ -1,0 +1,144 @@
+from test_plus import APITestCase
+
+from tests.profile.factories import ProfileFactory
+from tests.points.factories import (
+    ProfileCategoryFactory, ThemeFactory, CategoryFactory, LocationFactory
+)
+from tests.datasets.factories import GeographyFactory, GeographyHierarchyFactory
+from tests.boundaries.factories import GeographyBoundaryFactory
+
+
+class TestConsolidatedProfileView(APITestCase):
+
+    def setUp(self):
+        self.geography = GeographyFactory()
+        GeographyBoundaryFactory(geography=self.geography)
+        self.hierarchy = GeographyHierarchyFactory(root_geography=self.geography)
+        self.profile = ProfileFactory(geography_hierarchy=self.hierarchy)
+        self.theme1 = ThemeFactory(profile=self.profile, name="TH1")
+        self.theme2 = ThemeFactory(profile=self.profile, name="TH2")
+        self.category = CategoryFactory(profile=self.profile)
+        self.location = LocationFactory(category=self.category)
+        self.pc1_th1 = ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme1,
+            label="PC1 TH1"
+        )
+        self.pc2_th1 = ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme1,
+            label="PC2 TH1"
+        )
+        self.pc1_th2 = ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme2,
+            label="PC1 TH2"
+        )
+        self.pc2_th2 = ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme2,
+            label="PC2 TH2"
+        )
+
+    def test_profile_theme_data(self):
+        response = self.get(
+            'all-details', profile_id=self.profile.pk,
+            geography_code=self.geography.code, extra={'format': 'json'}
+        )
+        self.assert_http_200_ok()
+
+        theme_data = response.data["themes"]
+        assert len(theme_data) == 2
+        assert theme_data[0]["name"] == "TH1"
+        assert theme_data[1]["name"] == "TH2"
+        assert len(theme_data[0]["subthemes"]) == 2
+        assert len(theme_data[1]["subthemes"]) == 2
+        assert theme_data[0]["subthemes"][0]['label'] == "PC1 TH1"
+        assert theme_data[0]["subthemes"][1]['label'] == "PC2 TH1"
+        assert theme_data[1]["subthemes"][0]['label'] == "PC1 TH2"
+        assert theme_data[1]["subthemes"][1]['label'] == "PC2 TH2"
+
+    def test_theme_reoder(self):
+
+        # Reorder themes
+        self.theme2.order = 0
+        self.theme2.save()
+        self.theme1.order = 1
+        self.theme1.save()
+
+        response = self.get(
+            'all-details', profile_id=self.profile.pk,
+            geography_code=self.geography.code, extra={'format': 'json'}
+        )
+        self.assert_http_200_ok()
+
+        theme_data = response.data["themes"]
+        assert len(theme_data) == 2
+        assert theme_data[0]["name"] == "TH2"
+        assert theme_data[1]["name"] == "TH1"
+
+    def test_subtheme_reoder(self):
+
+        self.pc2_th1.order = 0
+        self.pc2_th1.save()
+        self.pc1_th1.order = 1
+        self.pc1_th1.save()
+
+        response = self.get(
+            'all-details', profile_id=self.profile.pk,
+            geography_code=self.geography.code, extra={'format': 'json'}
+        )
+        self.assert_http_200_ok()
+
+        # Assert if TH1 subthemes have different ordering from initial and
+        # TH2 subthemes have same order
+        theme_data = response.data["themes"]
+        assert theme_data[0]["subthemes"][0]['label'] == "PC2 TH1"
+        assert theme_data[0]["subthemes"][1]['label'] == "PC1 TH1"
+        assert theme_data[1]["subthemes"][0]['label'] == "PC1 TH2"
+        assert theme_data[1]["subthemes"][1]['label'] == "PC2 TH2"
+
+        # Change ordering of TH2 subthemes as well
+        self.pc2_th2.order = 0
+        self.pc2_th2.save()
+        self.pc1_th2.order = 1
+        self.pc1_th2.save()
+
+        response = self.get(
+            'all-details', profile_id=self.profile.pk,
+            geography_code=self.geography.code, extra={'format': 'json'}
+        )
+        self.assert_http_200_ok()
+
+        # Assert if TH1 subthemes have different ordering from initial and
+        # TH2 subthemes have same order
+        theme_data = response.data["themes"]
+        assert theme_data[0]["subthemes"][0]['label'] == "PC2 TH1"
+        assert theme_data[0]["subthemes"][1]['label'] == "PC1 TH1"
+        assert theme_data[1]["subthemes"][0]['label'] == "PC2 TH2"
+        assert theme_data[1]["subthemes"][1]['label'] == "PC1 TH2"
+
+        # Create 2 new pc for TH1 and inster one is first place and another on last
+        ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme1,
+            label="PC3 TH1", order=0
+        )
+        ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=self.theme1,
+            label="PC4 TH1", order=3
+        )
+
+        self.pc2_th1.order = 1
+        self.pc2_th1.save()
+        self.pc1_th1.order = 2
+        self.pc1_th1.save()
+
+        response = self.get(
+            'all-details', profile_id=self.profile.pk,
+            geography_code=self.geography.code, extra={'format': 'json'}
+        )
+        self.assert_http_200_ok()
+
+        # Assert if TH1 subthemes have different ordering from initial and
+        # TH2 subthemes have same order
+        theme_data = response.data["themes"]
+        assert theme_data[0]["subthemes"][0]['label'] == "PC3 TH1"
+        assert theme_data[0]["subthemes"][1]['label'] == "PC2 TH1"
+        assert theme_data[0]["subthemes"][2]['label'] == "PC1 TH1"
+        assert theme_data[0]["subthemes"][3]['label'] == "PC4 TH1"

--- a/wazimap_ng/points/views.py
+++ b/wazimap_ng/points/views.py
@@ -83,9 +83,11 @@ def boundary_point_count_helper(profile, geography):
             .values(
                 "category__profilecategory__id", "category__profilecategory__label",
                 "category__profilecategory__color",
+                "category__profilecategory__order",
                 "category__profilecategory__theme__name",
                 "category__profilecategory__theme__icon",
                 "category__profilecategory__theme__id",
+                "category__profilecategory__theme__order",
                 "category__metadata__source", "category__metadata__description",
                 "category__metadata__licence"
             )
@@ -103,6 +105,7 @@ def boundary_point_count_helper(profile, geography):
                 "name": lc["category__profilecategory__theme__name"],
                 "id": lc["category__profilecategory__theme__id"],
                 "icon": lc["category__profilecategory__theme__icon"],
+                "order": lc["category__profilecategory__theme__order"],
                 "subthemes": []
             }
             theme_dict[id] = theme
@@ -113,12 +116,20 @@ def boundary_point_count_helper(profile, geography):
             "id": lc["category__profilecategory__id"],
             "count": lc["count_category"],
             "color": lc["category__profilecategory__color"],
+            "order": lc["category__profilecategory__order"],
             "metadata": {
                 "source": lc["category__metadata__source"],
                 "description": lc["category__metadata__description"],
                 "licence": lc["category__metadata__licence"],
             }
         })
+
+    res = sorted(res, key=lambda k: k['order'])
+    for idx, r in enumerate(res):
+        if "subthemes" in r and r["subthemes"]:
+            subthemes = r["subthemes"]
+            subthemes = sorted(subthemes, key=lambda k: k['order'])
+            res[idx]["subthemes"] = subthemes
 
     return res
 


### PR DESCRIPTION
## Description
Refactor serialisers so we can use same serializer in:
* Detail_view
* Pc view
* theme view
(Not possible to use same serializer as it does too many requests to achieve same results)

Add Order field in (Already implemented):
* Pc model
* Theme model.

Both of these fields should be orderable from admin panel using sortable2  widget.(Already implemented)

Order should also change in api according to admin list order of data.

## Related Issue
#199 

## How to test it locally
Change order of theme and profile category in admin panel and order of themes and subthemes of all_detail api should also change.

## Changelog
Added sorting code in point views.py

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
