### PR TITLE
Enable tracing in sentry

### DIFF
--- a/wazimap_ng/config/common.py
+++ b/wazimap_ng/config/common.py
@@ -21,12 +21,16 @@ class Common(QCluster, Configuration):
 
     SERVER_INSTANCE = os.environ.get("SERVER_INSTANCE", "Dev")
     RELEASE = f"{SERVER_INSTANCE}"
+    SENTRY_ENVIRONMENT = f"BE_{SERVER_INSTANCE}"
     SENTRY_DSN = os.environ.get("SENTRY_DSN", None)
+    SENTRY_PERF_SAMPLE_RATE = os.environ.get("SENTRY_PERF_SAMPLE_RATE", 0.1)
 
     if SENTRY_DSN:
         sentry_sdk.init(SENTRY_DSN,
             integrations=[DjangoIntegration(), RedisIntegration()],
             send_default_pii=True,
+            traces_sample_rate=SENTRY_PERF_SAMPLE_RATE,
+            environment=SENTRY_ENVIRONMENT,
             release=RELEASE
         )
 


### PR DESCRIPTION
## Description
I want to get a better look inside some of the queries we run and that
are very slow, the best way to do it is on production/staging to get a
more closer look at the reality.
adding the tracing to 10% as other projects from OpenUp have done before
also adding the environment for the BE so that we can distinguish
between staging and production not using the release method (they should
be used for actual releases)

## Related Issue

## How to test it locally

## Changelog

### Added
`SENTRY_PERF_SAMPLE_RATE` as env variable 
using `SERVER_INSTANCE` for sentry environments.

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
