### PR TITLE
fix: changing a subcategory for profile indicator

### DIFF
--- a/tests/profile/admin/test_profile_indicator_admin.py
+++ b/tests/profile/admin/test_profile_indicator_admin.py
@@ -1,0 +1,73 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.test import SimpleTestCase, TestCase
+
+from tests.profile.factories import ProfileIndicatorFactory, ProfileFactory, IndicatorCategoryFactory, IndicatorSubcategoryFactory
+from wazimap_ng.profile.models import ProfileIndicator
+from wazimap_ng.profile.admin.admins import ProfileIndicatorAdmin
+
+class MockRequest:
+    pass
+
+
+class MockSuperUser:
+    def has_perm(self, perm, obj=None):
+        return True
+
+    @property
+    def is_superuser(self):
+        return True
+
+
+request = MockRequest()
+request.user = MockSuperUser()
+
+@pytest.mark.focus
+class ProfileIndicatorAdminTests(TestCase):
+
+    @classmethod
+    def setUpTestData(self):
+        profile = ProfileFactory()
+        indicatorcategory = IndicatorCategoryFactory(profile=profile)
+        self.subcategory = IndicatorSubcategoryFactory(category=indicatorcategory)
+        self.profile_indicator = ProfileIndicatorFactory(profile=profile)
+
+    def setUp(self):
+        self.site = AdminSite()
+
+    def test_modeladmin_str(self):
+        ma = ProfileIndicatorAdmin(ProfileIndicator, self.site)
+        self.assertEqual(str(ma), 'profile.ProfileIndicatorAdmin')
+
+
+    def test_fieldset(self):
+        ma = ProfileIndicatorAdmin(ProfileIndicator, self.site)
+        request.method = 'GET'
+        self.assertEqual(list(ma.get_form(request, self.profile_indicator).base_fields), ['indicator', 'label', 'subcategory', 'description', 'choropleth_method', 'chart_configuration'])
+
+    def test_subcategories_for_indicator(self):
+        ma = ProfileIndicatorAdmin(ProfileIndicator, self.site)
+        request.method = 'GET'
+        form = ma.get_form(request, self.profile_indicator)()
+
+        self.assertHTMLEqual(
+            str(form["subcategory"]),
+            '<div class="related-widget-wrapper">'
+            '<select name="subcategory" id="id_subcategory" required>'
+            '<option value="" selected>---------</option>'
+            f'<option value="{self.subcategory.id}">{self.profile_indicator.profile.name}: {self.subcategory.category.name} -&gt; {self.subcategory.name}</option>'
+            '</select></div>'
+        )
+
+    def test_subcategories_empty(self):
+        ma = ProfileIndicatorAdmin(ProfileIndicator, self.site)
+        request.method = 'GET'
+        form = ma.get_form(request)()
+
+        self.assertHTMLEqual(
+            str(form["subcategory"]),
+            '<div class="related-widget-wrapper">'
+            '<select name="subcategory" id="id_subcategory" required>'
+            '<option value="" selected>---------</option>'
+            '</select></div>'
+        )

--- a/tests/profile/factories.py
+++ b/tests/profile/factories.py
@@ -8,6 +8,7 @@ class ProfileFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = models.Profile
 
+    name = "Profile"
     geography_hierarchy = factory.SubFactory(datasets_factoryboy.GeographyHierarchyFactory)
 
 

--- a/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
@@ -64,6 +64,23 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel):
             obj.subindicators = obj.indicator.subindicators
         super().save_model(request, obj, form, change)
 
+    def get_form(self, request, obj=None, **kwargs):
+        form = super().get_form(request, obj, **kwargs)
+        qs = form.base_fields["subcategory"].queryset
+        if obj:
+            profile_id = obj.profile_id
+            if request.method == "POST":
+                profile_id = request.POST.get("profile", profile_id)
+            qs = models.IndicatorSubcategory.objects.filter(
+                category__profile_id=profile_id
+            )
+        elif not obj and request.method == "GET":
+             qs = qs = models.IndicatorSubcategory.objects.none()
+
+        form.base_fields["subcategory"].queryset = qs
+
+        return form
+
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
         field = super().formfield_for_foreignkey(db_field, request, **kwargs)
         if db_field.name == "indicator":

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -14,34 +14,4 @@ class ProfileIndicatorAdminForm(forms.ModelForm):
         widgets = {
             'indicator': VariableFilterWidget,
             'chart_configuration': JSONEditorWidget,
-
         }
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-        # do not show any subcategories by default,
-        # it should be loaded based on selected profile via JS
-        self.fields['subcategory'].choices = [["", "-----------"]]
-
-        # filter subcategories by profile if initial data provided
-        if self.data.get('profile'):
-            subcategories = models.IndicatorSubcategory.objects.filter(
-                category__profile_id=self.data['profile']
-            )
-            self.fields['subcategory'].choices += [
-                [obj.id, obj.name] for obj in subcategories
-            ]
-
-
-
-    def clean_subcategory(self):
-        subcategory = self.cleaned_data['subcategory']
-        profile = self.cleaned_data['profile']
-
-        # do not allow to save subcategory which not related to the selected profile
-        if subcategory.category.profile != profile:
-            msg = f'This subcategory cannot be selected with {profile} profile.'
-            raise ValidationError(msg)
-
-        return subcategory


### PR DESCRIPTION
## Description
the subcategory can now be changed again, removing the code from the
form and adding the same code that profilekeymetrics uses for the same
fxied the problem where the subcategory was not shown correctly and
therefore could not be saved
added tests for making sure the subindicator shows up when a profile
indicator is set

not super happy with the test, but works for now. 
## Related Issue

## How to test it locally

Go to a ProfileIndicator and try to change the subcategory. It should work again and you can save it. 

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
