### PR TITLE
Fixed incorrect data returned fomr get_indicator_data

### DIFF
--- a/tests/profile/serializers/test_indicator_data_serializer.py
+++ b/tests/profile/serializers/test_indicator_data_serializer.py
@@ -83,6 +83,6 @@ def test_get_indicator_data(geography, profile_indicators):
 
     profile2 = ProfileFactory()
     pi3 = ProfileIndicatorFactory(indicator=pi1.indicator, label="PI3", profile=profile2)
-    results = get_indicator_data(profile, geography)
+    results = get_indicator_data(profile, [geography])
     assert len(results) == 2
 

--- a/tests/profile/serializers/test_indicator_data_serializer.py
+++ b/tests/profile/serializers/test_indicator_data_serializer.py
@@ -72,3 +72,17 @@ def test_profile_indicator_metadata(geography, profile_indicators, metadata):
     assert output[0]["metadata_source"] == "A source"
     assert output[0]["metadata_description"] == "A description"
     assert output[0]["metadata_url"] == "http://example.com"
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("indicator_data")
+def test_get_indicator_data(geography, profile_indicators):
+    
+    profile = profile_indicators[0].profile
+    pi1, pi2 = profile_indicators
+
+    profile2 = ProfileFactory()
+    pi3 = ProfileIndicatorFactory(indicator=pi1.indicator, label="PI3", profile=profile2)
+    results = get_indicator_data(profile, geography)
+    assert len(results) == 2
+

--- a/wazimap_ng/profile/serializers/indicator_data_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer.py
@@ -14,6 +14,7 @@ def get_indicator_data(profile, geography):
     data = (IndicatorData.objects
         .filter(
             indicator__in=profile.indicators.all(),
+            indicator__profileindicator__profile=profile,
             geography=geography
         )
         .values(


### PR DESCRIPTION
## Description
When two profile_indicators from different profiles used the same
indicator, get_indicator_data returned them both. This fix explicitly
sets the correct profile.

## Related Issue
#176 

## How to test it locally

This is difficult to test since the code causing the problem is an inner function. Hopefully the unit test serves as sufficient documentation

## Changelog

### Added

### Updated
Fixed get_indicator_data function to only return indicator_data from a given profile

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
