### PR TITLE
MetricsSerializer breaks for missing subindicator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
+This is the backend for Wazimap-NG.
+
 # Introduction
+
 Wazimap-NG is the next version of [Wazimap](http://www.wazimap.co.za). It provides a platform for users to bind tabular data to spatial boundaries in order create curated views of datasets. Yes - that's probably too vague a description to understand what it is. Hopefully the images below provide a better description:
 
 <a href="https://postimg.cc/G8XkZRhV" target="_blank"><img src="https://i.postimg.cc/G8XkZRhV/Screen-Shot-2020-09-27-at-09-50-00.png" alt="Screen-Shot-2020-09-27-at-09-50-00"/></a> <a href="https://postimg.cc/MM67PHx1" target="_blank"><img src="https://i.postimg.cc/MM67PHx1/Screen-Shot-2020-09-27-at-09-50-33.png" alt="Screen-Shot-2020-09-27-at-09-50-33"/></a><br/><br/>
@@ -42,19 +45,24 @@ Version 0.8 is due soon and will fix bugs that currently don't have workarounds.
 
 # Local Development
 
-Start the dev server for local development. Before you've created your database, the webserver will break because it can't find the database.
-```bash
-docker-compose up
-```
+Local development is normally done inside docker-compose so that the supporting services are available and the environment is very similar to how the application is run in production.
 
-curl https://wazimap-ng.s3-eu-west-1.amazonaws.com/wazimap_ng-2020203.bak.gz | gunzip -c | docker exec -i wazimap-ng_db_1 pg_restore -U postgres -d wazimap_ng
-```
+Make docker-compose start the supporting services using
 
-If this is the first time you're running this, bring the containers down, then up again
-```bash
-docker-compose down
-docker-compose up
-```
+    docker-compose run --rm web python wait_for_postgres.py
+      
+Run the tests using
+
+    docker-compose run --rm -e DJANGO_CONFIGURATION=Test web pytest /app/tests
+    
+Start the backend using 
+
+    docker-compose up
+    
+Run Django manage commands inside docker-compose, e.g. create a superuser:
+
+    docker-compose run --rm web python manage.py createsuperuser
+
 
 # Documentation
 These are works in progress:

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -28,12 +28,22 @@ def sibling(profile_key_metric, geography):
     return None
 
 def absolute_value(profile_key_metric, geography):
-    indicator_data = IndicatorData.objects.filter(indicator__profilekeymetrics=profile_key_metric, geography=geography)
+    indicator_data = IndicatorData.objects.filter(
+        indicator__profilekeymetrics=profile_key_metric, geography=geography
+    )
     if indicator_data.count() > 0:
         subindicator = get_subindicator(profile_key_metric)
-        data = indicator_data.first().data # TODO what to do with multiple results
-        return data["subindicators"][subindicator]
+        data = indicator_data.first().data  # TODO what to do with multiple results
+        subindicators_data = data.get("subindicators")
+        if subindicators_data:
+            absolute_value = subindicators_data.get(subindicator)
+            if absolute_value:
+                return absolute_value
+            # if the subindicator is missing
+            return "N/A"
+
     return None
+
 
 def subindicator(profile_key_metric, geography):
     indicator_data = IndicatorData.objects.filter(indicator__profilekeymetrics=profile_key_metric, geography=geography)

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -39,10 +39,8 @@ def absolute_value(profile_key_metric, geography):
             absolute_value = subindicators_data.get(subindicator)
             if absolute_value:
                 return absolute_value
-            # if the subindicator is missing
-            return "N/A"
-
-    return None
+    # if the subindicator is missing
+    return "N/A"
 
 
 def subindicator(profile_key_metric, geography):


### PR DESCRIPTION
issue [203]

## Description
There was an Exception raised on not getting the value of  key **subindicators**

## Related Issue
This bug was related to this [issue](https://github.com/OpenUpSA/wazimap-ng/issues/203)
## How to test it locally

## Changelog

### Added

### Updated
`data["subindicators"][subindicator]` was updated by` subindicators_data = data.get("subindicators")` and then by `absolute_value = subindicators_data.get(subindicator)` , now .get will return none in case there is no value found and by default the value will be "N/A" on having no value 

**_Before_**
![image](https://user-images.githubusercontent.com/29105699/110810411-97088780-82a7-11eb-81fd-47bf9197c6db.png)

**_After_**
![image](https://user-images.githubusercontent.com/29105699/110810478-a8519400-82a7-11eb-8e88-68b00454764a.png)

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 [issue linked](https://github.com/OpenUpSA/wazimap-ng/issues/203)
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
