### PR TITLE
Feature/send profile category color

### DIFF
--- a/tests/general/factories.py
+++ b/tests/general/factories.py
@@ -1,0 +1,11 @@
+import factory
+
+from wazimap_ng.general.models import MetaData
+
+from tests.datasets.factories import LicenceFactory
+
+class MetaDataFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = MetaData
+
+    licence = factory.SubFactory(LicenceFactory)

--- a/tests/points/conftest.py
+++ b/tests/points/conftest.py
@@ -1,0 +1,17 @@
+import pytest
+
+from tests.points.factories import ThemeFactory, ProfileCategoryFactory
+from tests.profile.factories import ProfileFactory
+
+
+@pytest.fixture
+def profile():
+    return ProfileFactory()
+
+@pytest.fixture
+def theme():
+    return ThemeFactory()
+
+@pytest.fixture
+def profile_category(theme):
+    return ProfileCategoryFactory(theme=theme, label="profile category name", description="my test profile category")

--- a/tests/points/conftest.py
+++ b/tests/points/conftest.py
@@ -14,4 +14,4 @@ def theme():
 
 @pytest.fixture
 def profile_category(theme):
-    return ProfileCategoryFactory(theme=theme, label="profile category name", description="my test profile category")
+    return ProfileCategoryFactory(theme=theme, label="profile category name", description="my test profile category", color="red")

--- a/tests/points/conftest.py
+++ b/tests/points/conftest.py
@@ -14,4 +14,4 @@ def theme():
 
 @pytest.fixture
 def profile_category(theme):
-    return ProfileCategoryFactory(theme=theme, label="profile category name", description="my test profile category", color="red")
+    return ProfileCategoryFactory(theme=theme, label="profile category name", description="my test profile category", color="red", profile=theme.profile)

--- a/tests/points/factories.py
+++ b/tests/points/factories.py
@@ -4,6 +4,7 @@ from django.contrib.gis.geos import Point
 
 from wazimap_ng.points.models import Category, CoordinateFile, ProfileCategory, Theme, Location
 from tests.profile.factories import ProfileFactory
+from tests.general.factories import MetaDataFactory
 
 
 class ThemeFactory(factory.django.DjangoModelFactory):
@@ -19,6 +20,8 @@ class CategoryFactory(factory.django.DjangoModelFactory):
         model = Category
 
     profile = factory.SubFactory(ProfileFactory)
+    metadata = factory.SubFactory(MetaDataFactory)
+    
     name = "Category"
 
 

--- a/tests/points/test_serializers.py
+++ b/tests/points/test_serializers.py
@@ -8,7 +8,8 @@ from django.db.models import ImageField
 import pytest
 from pydoc import locate
 
-from wazimap_ng.points.serializers import LocationSerializer
+from wazimap_ng.points.serializers import LocationSerializer, ProfileCategorySerializer, InlineThemeSerializer
+from wazimap_ng.general.serializers import MetaDataSerializer
 from wazimap_ng.points.models import Location, Category
 from wazimap_ng.profile.models import Profile
 
@@ -47,6 +48,20 @@ class SerializerAssertWithContext(HasContext, Geoserializer, SerializerAssert):
 def assert_serializer(cls):
     return SerializerAssertWithContext(cls)
 
+@pytest.mark.django_db
+class TestProfileCollectionSerializer:
+    def test_basic_serialization(self, profile_category):
+        serializer = ProfileCategorySerializer(instance=profile_category)
+        theme_serializer = InlineThemeSerializer(instance=profile_category.theme)
+        metadata_serializer = MetaDataSerializer(instance=profile_category.category.metadata)
+        
+        assert serializer.data == {
+            "id": profile_category.id,
+            "name": profile_category.label,
+            "description": profile_category.description,
+            "theme": theme_serializer.data,
+            "metadata": metadata_serializer.data,
+        }
 
 class TestLocationSerializer:
 

--- a/tests/points/test_serializers.py
+++ b/tests/points/test_serializers.py
@@ -61,6 +61,7 @@ class TestProfileCollectionSerializer:
             "description": profile_category.description,
             "theme": theme_serializer.data,
             "metadata": metadata_serializer.data,
+            "color": "red"
         }
 
 class TestLocationSerializer:

--- a/wazimap_ng/points/serializers.py
+++ b/wazimap_ng/points/serializers.py
@@ -55,7 +55,7 @@ class ProfileCategorySerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.ProfileCategory
-        fields = ('id', 'name', 'description', 'theme', 'metadata',)
+        fields = ("id", "name", "description", "theme", "metadata", "color")
 
 class ThemeSerializer(serializers.ModelSerializer):
     categories = ProfileCategorySerializer(many=True, source="profile_categories")

--- a/wazimap_ng/points/serializers.py
+++ b/wazimap_ng/points/serializers.py
@@ -3,8 +3,9 @@ from rest_framework import serializers
 from django.core.serializers import serialize
 
 from . import models
-from wazimap_ng.general.serializers import LicenceSerializer, MetaDataSerializer
+from wazimap_ng.general.serializers import MetaDataSerializer
 from wazimap_ng.profile.serializers import SimpleProfileSerializer as ProfileSerializer
+from wazimap_ng.datasets.serializers import LicenceSerializer
 
 class SimpleThemeSerializer(serializers.ModelSerializer):
     class Meta:


### PR DESCRIPTION
## Description
Added the color field to the ProfileCategorySerializer
Added serializer and view tests

## Related Issue
None

## How to test it locally
1. Create a new profile category in the django backend
2. Look at the generated json using the api, e.g. http://localhost:8000/api/v1/profile/8/points/themes/
3. Look for the color key in each category

## Changelog

### Added
Unit tests for the ProfileCategorySerializer and relevant view

### Updated
Added color field to the ProfileCategorySerializer

### Removed

## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- []  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
