### PR TITLE
Fixed issue with duplicate subindicator groups when dataset is re-uploaded

### DIFF
--- a/tests/datasets/test_dataloader.py
+++ b/tests/datasets/test_dataloader.py
@@ -106,10 +106,10 @@ class TestLoadData:
         assert len(warnings) == 0
         assert len(errors) == 1
 
-    @patch('wazimap_ng.datasets.models.Group.objects')
     @patch('wazimap_ng.datasets.models.DatasetData')
     @patch('wazimap_ng.datasets.dataloader.load_geography')
-    def test_datasetdata_created(self, load_geography, MockDatasetData, group_objects, good_input_with_groups):
+    @patch('wazimap_ng.datasets.dataloader.create_groups')
+    def test_datasetdata_created(self, create_groups, load_geography, MockDatasetData, good_input_with_groups):
         data = good_input_with_groups
         dataset = Mock(spec=models.Dataset)
 
@@ -174,7 +174,7 @@ def subindicatorGroup(dataset):
 @pytest.mark.django_db
 class TestCreateGroups:
 
-    def test_create_groups(self, dataset):
+    def test_create_groups_without_subindicator_in_datasatdata(self, dataset):
         assert dataset.group_set.count() == 0
 
         dataloader.create_groups(dataset, ["group1", "group2"])
@@ -188,14 +188,7 @@ class TestCreateGroups:
         assert groups[1].dataset == dataset
         assert groups[1].subindicators == []
 
-    def test_return_groups(self, dataset):
-
-        groups = dataloader.create_groups(dataset, ["group1", "group2"])
-        assert len(groups) == 2
-        assert groups[0].name == "group1"
-        assert groups[1].name == "group2"
-
-    def test_populates_subindicators(self, dataset, datasetData):
+    def test_groups_with_subindicators_in_datasetdata(self, dataset, datasetData):
 
         groups = dataloader.create_groups(dataset, ["group1", "group2"])
         assert len(groups) == 2

--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -22,7 +22,14 @@ def create_groups(dataset, group_names):
     groups = []
     for g in group_names:
         subindicators = list(models.DatasetData.objects.get_unique_subindicators(g))
-        group = models.Group.objects.create(name=g, dataset=dataset, subindicators=subindicators)
+
+        group = models.Group.objects.filter(name=g, dataset=dataset).first()
+        if group:
+            group.subindicators = subindicators
+            group.save()
+        else:
+            group = models.Group.objects.create(name=g, dataset=dataset, subindicators=subindicators)
+
         groups.append(group)
     return groups
 

--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -23,13 +23,11 @@ def create_groups(dataset, group_names):
     for g in group_names:
         subindicators = list(models.DatasetData.objects.get_unique_subindicators(g))
 
-        group = models.Group.objects.filter(name=g, dataset=dataset).first()
-        if group:
-            group.subindicators = subindicators
-            group.save()
-        else:
-            group = models.Group.objects.create(name=g, dataset=dataset, subindicators=subindicators)
-
+        group, created = models.Group.objects.get_or_create(
+            name=g, dataset=dataset
+        )
+        group.subindicators = subindicators
+        group.save()
         groups.append(group)
     return groups
 


### PR DESCRIPTION
## Description
Duplicate subindicator groups when dataset is updated.

## Related Issue
#193 

## How to test it locally

Create a new dataset.
Reupload same file on same dataset.
Previously re uploading file with same groups created a duplicate subindicator group.
Now it should be fixed and subindicator list should be updated according to new upload

## Changelog

* Changed `create_groups` in `datasets/dataloader.py`
* Added tests in `datasets/test_dataloader`

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
