### PR TITLE
Fixed cache for points api endpoint

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -126,7 +126,7 @@ def test_update_point_cache_signal(mock_datetime):
 
     mock_datetime.now.return_value = "Some time"
 
-    cache.update_point_cache(category)
+    cache.update_point_cache(profile, category)
 
     key = "etag-Location-profile-%s-%s" % (profile.id, category.id)
 

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -89,35 +89,43 @@ def update_point_cache(profile, category):
     cache.set(key1, datetime.now())
 
 
+@receiver(post_delete, sender=ProfileIndicator)
 @receiver(post_save, sender=ProfileIndicator)
 def profile_indicator_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
+@receiver(post_delete, sender=ProfileHighlight)
 @receiver(post_save, sender=ProfileHighlight)
 def profile_highlight_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
+@receiver(post_delete, sender=IndicatorCategory)
 @receiver(post_save, sender=IndicatorCategory)
 def profile_category_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
+@receiver(post_delete, sender=IndicatorSubcategory)
 @receiver(post_save, sender=IndicatorSubcategory)
 def profile_subcategory_updated(sender, instance, **kwargs):
     update_profile_cache(instance.category.profile)
 
 
+@receiver(post_delete, sender=ProfileKeyMetrics)
 @receiver(post_save, sender=ProfileKeyMetrics)
 def profile_keymetrics_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
+@receiver(post_delete, sender=Profile)
 @receiver(post_save, sender=Profile)
 def profile_updated(sender, instance, **kwargs):
     update_profile_cache(instance)
 
+
+@receiver(post_delete, sender=Group)
 @receiver(post_save, sender=Group)
 def subindicator_group_update(sender, instance, **kwargs):
     indicator_ids = instance.dataset.indicator_set.values_list("id", flat=True)
@@ -139,6 +147,7 @@ def point_updated_location(sender, instance, **kwargs):
         update_profile_cache(pc.profile)
 
 
+@receiver(post_delete, sender=Category)
 @receiver(post_save, sender=Category)
 def point_updated_category(sender, instance, **kwargs):
     profile_categoies = instance.profilecategory_set.all()
@@ -154,6 +163,7 @@ def point_updated_profile_category(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
+@receiver(post_delete, sender=Indicator)
 @receiver(post_save, sender=Indicator)
 def indicator_updated(sender, instance, **kwargs):
     indicator_id = instance.id
@@ -166,6 +176,7 @@ def indicator_updated(sender, instance, **kwargs):
         update_profile_cache(profile_obj)
 
 
+@receiver(post_delete, sender=Geography)
 @receiver(post_save, sender=Geography)
 def geography_updated(sender, instance, **kwargs):
 
@@ -189,6 +200,7 @@ def geography_updated(sender, instance, **kwargs):
         update_profile_cache(profile)
 
 
+@receiver(post_delete, sender=GeographyHierarchy)
 @receiver(post_save, sender=GeographyHierarchy)
 def geography_hierarchy_updated(sender, instance, **kwargs):
     for profile in instance.profile_set.all():

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.core.cache import cache
 from django.db.models import Q
-from django.db.models.signals import post_save
+from django.db.models.signals import post_save, post_delete
 from django.dispatch import receiver
 from django.http import Http404
 from django.views.decorators.cache import cache_control
@@ -132,14 +132,17 @@ def subindicator_group_update(sender, instance, **kwargs):
         update_profile_cache(profile_obj)
 
 
+@receiver(post_delete, sender=Location)
 @receiver(post_save, sender=Location)
 def point_updated_location(sender, instance, **kwargs):
-    update_point_cache(instance.category)
+    for pc in instance.category.profilecategory_set.all():
+        update_point_cache(pc)
 
 
 @receiver(post_save, sender=Category)
 def point_updated_category(sender, instance, **kwargs):
-    update_point_cache(instance)
+    for pc in instance.profilecategory_set.all():
+        update_point_cache(instance)
 
 
 @receiver(post_save, sender=Indicator)


### PR DESCRIPTION
## Description
Fixed cache for points api endpoint

## Related Issue
#195

## How to test it locally
Visit http://localhost:8000/api/v1/profile/1/points/category/1/points/?format=json
Open location object in admin panel that exist in api endpoint above
Change data in location, save and refresh the api endpoint above and location data should change.

Delete location and refresh api endpoint.
Location should be removed from response

## Changelog
Changed cache.py to update profile categories linked to location category

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
