### PR TITLE
Added profile indicator id to indicatordata serializer

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,11 @@ def geographies():
 def geography(geographies):
     return geographies[0]
 
+
 @pytest.fixture
 def other_geographies(geographies):
     return geographies[1:]
+
 
 @pytest.fixture
 def geography_hierarchy(geography):
@@ -63,12 +65,13 @@ def child_geographies(geography):
 
 @pytest.fixture
 def profile(geography_hierarchy):
-    
+
     configuration = {
         "urls": ["some_domain.com"]
     }
 
     return ProfileFactory(geography_hierarchy=geography_hierarchy, configuration=configuration)
+
 
 @pytest.fixture
 def dataset(profile):
@@ -123,11 +126,12 @@ def datasetdata(indicator, geography):
                            "gender": "female", "age": "17", "language": "isiZulu", "count": 12}),
     ]
 
+
 @pytest.fixture
 def child_datasetdata(datasetdata, geography):
     def gendict(d, g): return {**d.data, **{"geography": g.pk}}
     dataset = datasetdata[0].dataset
-    
+
     new_datasetdata = [
         DatasetDataFactory(dataset=dataset, geography=g, data=gendict(d, g))
         for g in geography.get_children()
@@ -135,6 +139,7 @@ def child_datasetdata(datasetdata, geography):
     ]
 
     return new_datasetdata
+
 
 @pytest.fixture
 def metadata(licence):
@@ -166,12 +171,14 @@ def indicatordata(indicator, indicatordata_json, geography):
         IndicatorDataFactory(indicator=indicator, geography=geography, data=indicatordata_json)
     ]
 
+
 @pytest.fixture
 def other_geographies_indicatordata(indicator, indicatordata_json, other_geographies):
     return [
         IndicatorDataFactory(indicator=indicator, geography=g, data=indicatordata_json)
         for g in other_geographies
     ]
+
 
 @pytest.fixture
 def child_indicatordata(indicator, indicatordata_json, child_geographies):
@@ -189,6 +196,22 @@ def child_indicatordata(indicator, indicatordata_json, child_geographies):
 def profile_indicator(profile, indicatordata):
     indicator = indicatordata[0].indicator
     return ProfileIndicatorFactory(profile=profile, indicator=indicator)
+
+
+@pytest.fixture
+def category(profile_indicator):
+    c = profile_indicator.subcategory.category
+    c.name = "A test category"
+    c.save()
+    return c
+
+
+@pytest.fixture
+def subcategory(profile_indicator):
+    s = profile_indicator.subcategory
+    s.name = "A test subcategory"
+    s.save()
+    return s
 
 
 @pytest.fixture

--- a/wazimap_ng/profile/serializers/indicator_data_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer.py
@@ -27,6 +27,7 @@ def get_indicator_data(profile, indicators, geographies):
                 geography__in=geographies
             )
             .values(
+                profile_indicator_id=F("indicator__profileindicator__id"),
                 jsdata=F("data"),
                 description=F("indicator__profileindicator__description"),
                 indicator_name=F("indicator__name"),
@@ -106,6 +107,7 @@ def IndicatorDataSerializer(profile, geography):
                              lambda x: "indicators",
                              "profile_indicator_label",
                              lambda x: {
+                                 "id": x["profile_indicator_id"],
                                  "description": x["description"],
                                  "choropleth_method": x["choropleth_method"],
                                  "metadata": {


### PR DESCRIPTION
## Description
Added profile indicator id to the indicator data serializer

## Related Issue
N/A

## How to test it locally
Call an all details url, e.g. look for an id key inside each indicator. Compare this id with the id of the profile indicator in the database
http://localhost:8000/api/v1/all_details/profile/8/geography/NMA/?format=json

## Changelog

### Added
Added "id" key to indicatordata serializer

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
