### PR TITLE
API for profile indicators to provide last updated date

### DIFF
--- a/tests/profile/views/test_views.py
+++ b/tests/profile/views/test_views.py
@@ -7,7 +7,8 @@ import pytest
 from tests.profile.factories import ProfileFactory, IndicatorCategoryFactory, IndicatorSubcategoryFactory, ProfileIndicatorFactory
 from tests.datasets.factories import DatasetFactory, IndicatorFactory, IndicatorDataFactory, GroupFactory
 
-from wazimap_ng.profile.views import ProfileByUrl
+from wazimap_ng.profile.views import ProfileByUrl, ProfileDetail
+
 
 @pytest.mark.django_db
 class TestProfileGeographyData(APITestCase):
@@ -46,6 +47,17 @@ class TestProfileGeographyData(APITestCase):
         data = response.data["profile_data"]["Category"]["subcategories"]["Subcategory"]["indicators"]["Indicator"]["data"]
 
         assert data == expected_data
+
+
+    def test_profile_last_update(self):
+
+        response = self.get('profile-detail',
+            pk=self.profile.pk
+
+        )
+        is_last_update_present = response.data.get("indicators")[0].get("last_updated")
+        assert bool(is_last_update_present) == True
+
 
 
 @pytest.mark.django_db

--- a/wazimap_ng/profile/serializers/profile_indicator_serializer.py
+++ b/wazimap_ng/profile/serializers/profile_indicator_serializer.py
@@ -11,12 +11,16 @@ from .indicator_data_serializer import get_indicator_data
 class ProfileIndicatorSerializer(serializers.ModelSerializer):
     subcategory = serializers.SerializerMethodField()
     category = serializers.SerializerMethodField()
+    last_updated = serializers.SerializerMethodField()
 
     def get_category(self, obj):
         return obj.subcategory.category.name
 
     def get_subcategory(self, obj):
         return obj.subcategory.name
+
+    def get_last_updated(self, obj):
+        return obj.updated
 
     class Meta:
         model = ProfileIndicator


### PR DESCRIPTION
## Description
The ProfileIndicator API endpoint should include the last_updated date.

## Related Issue
closes #239

## How to test it locally
` sudo docker-compose run --rm -e DJANGO_CONFIGURATION=Test web pytest -s /app/tests/profile/views/test_views.py::TestProfileGeographyData`
## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
