### PR TITLE
Fix: 500 error on Dataset validation

### DIFF
--- a/wazimap_ng/datasets/admin/forms/dataset_admin_form.py
+++ b/wazimap_ng/datasets/admin/forms/dataset_admin_form.py
@@ -6,6 +6,12 @@ from wazimap_ng.general.services.permissions import get_user_group
 class DatasetAdminForm(forms.ModelForm):
     import_dataset = forms.FileField(required=False)
 
+    def clean_profile(self):
+        cleaned_data = super(DatasetAdminForm, self).clean()
+        if cleaned_data['profile'] is None:
+            raise forms.ValidationError('Profile is not set.')
+        return cleaned_data['profile']
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
## Description
During dataset upload, an Attribute error is thrown if profile is None, fixed this by writing the clean method for that field,  raising a Validation error if profile is None.

## Related Issue
#204

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
