### PR TITLE
Fix: Reverse Coordinates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM osgeo/gdal:ubuntu-small-latest
+FROM osgeo/gdal:ubuntu-small-3.1.3
 
 RUN apt-get update && apt-get install -y \
   postgresql-client vim less curl apt-transport-https \


### PR DESCRIPTION
## Description

Latest GDAL images honors the default OGRCoordinateTransformation class axis order which is `latitude, longitude` order. This causes coordinates of boundaries & points to be reversed from the expected `longitude, latitude` order.

This PR pins the `osgeo/gdal` image to a tag where the order is still `longitude, latitude`.

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
