### PR TITLE
Added a way to reset dataset data at the time of new upload

### DIFF
--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -32,11 +32,15 @@ def create_groups(dataset, group_names):
 
 
 @transaction.atomic
-def loaddata(dataset, iterable, row_number):
+def loaddata(dataset, iterable, row_number, reset=False):
     datarows = []
     errors = []
     warnings = []
     groups = set()
+
+    if reset:
+        logger.debug(f"Deleting previously uploaded data for this dataset")
+        dataset.datasetdata_set.all().delete()
 
     version = dataset.geography_hierarchy.version
 

--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -32,13 +32,13 @@ def create_groups(dataset, group_names):
 
 
 @transaction.atomic
-def loaddata(dataset, iterable, row_number, reset=False):
+def loaddata(dataset, iterable, row_number, overwrite=False):
     datarows = []
     errors = []
     warnings = []
     groups = set()
 
-    if reset:
+    if overwrite:
         logger.debug(f"Deleting previously uploaded data for this dataset")
         dataset.datasetdata_set.all().delete()
 

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -12,13 +12,13 @@ from ..dataloader import loaddata
 logger = logging.getLogger(__name__)
 
 
-def process_file_data(df, dataset, row_number):
+def process_file_data(df, dataset, row_number, reset):
     df = df.applymap(lambda s:s.strip() if type(s) == str else s)
     datasource = (dict(d[1]) for d in df.iterrows())
-    return loaddata(dataset, datasource, row_number)
+    return loaddata(dataset, datasource, row_number, reset)
 
 
-def process_csv(dataset, buffer, chunksize=1000000):
+def process_csv(dataset, buffer, reset, chunksize=1000000):
     encoding, wrapper_file = get_stream_reader(buffer)
     _, columns = clean_columns(wrapper_file)
     row_number = 1
@@ -29,7 +29,7 @@ def process_csv(dataset, buffer, chunksize=1000000):
     for df in pd.read_csv(wrapper_file, chunksize=chunksize, dtype=str, sep=",", header=None, skiprows=1, encoding=encoding):
         df.dropna(how='all', axis='columns', inplace=True)
         df.columns = columns
-        errors, warnings = process_file_data(df, dataset, row_number)
+        errors, warnings = process_file_data(df, dataset, row_number, reset)
         error_logs = error_logs + errors
         warning_logs = warning_logs + warnings
         row_number = row_number + chunksize
@@ -55,6 +55,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     filename = dataset_file.document.name
     chunksize = getattr(settings, "CHUNK_SIZE_LIMIT", 1000000)
+    reset_datasetdata = kwargs.get("reset", False)
     logger.debug(f"Processing: {filename}")
 
     columns = None
@@ -64,7 +65,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     if ".csv" in filename:
         logger.debug(f"Processing as csv")
-        csv_output = process_csv(dataset, dataset_file.document.open("rb"), chunksize)
+        csv_output = process_csv(dataset, dataset_file.document.open("rb"), reset_datasetdata, chunksize)
         error_logs = csv_output["error_logs"]
         warning_logs = csv_output["warning_logs"]
         columns = csv_output["columns"]
@@ -86,7 +87,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
             else:
                 df.dropna(how='any', axis='columns', inplace=True)
                 df.columns = columns
-                errors, warnings = process_file_data(df, dataset, row_number)
+                errors, warnings = process_file_data(df, dataset, row_number, reset_datasetdata)
                 error_logs = error_logs + errors
                 warning_logs = warning_logs + warnings
                 row_number = row_number + chunksize

--- a/wazimap_ng/datasets/tasks/process_uploaded_file.py
+++ b/wazimap_ng/datasets/tasks/process_uploaded_file.py
@@ -12,13 +12,13 @@ from ..dataloader import loaddata
 logger = logging.getLogger(__name__)
 
 
-def process_file_data(df, dataset, row_number, reset):
+def process_file_data(df, dataset, row_number, overwrite=False):
     df = df.applymap(lambda s:s.strip() if type(s) == str else s)
     datasource = (dict(d[1]) for d in df.iterrows())
-    return loaddata(dataset, datasource, row_number, reset)
+    return loaddata(dataset, datasource, row_number, overwrite)
 
 
-def process_csv(dataset, buffer, reset, chunksize=1000000):
+def process_csv(dataset, buffer, overwrite=False, chunksize=1000000):
     encoding, wrapper_file = get_stream_reader(buffer)
     _, columns = clean_columns(wrapper_file)
     row_number = 1
@@ -29,7 +29,7 @@ def process_csv(dataset, buffer, reset, chunksize=1000000):
     for df in pd.read_csv(wrapper_file, chunksize=chunksize, dtype=str, sep=",", header=None, skiprows=1, encoding=encoding):
         df.dropna(how='all', axis='columns', inplace=True)
         df.columns = columns
-        errors, warnings = process_file_data(df, dataset, row_number, reset)
+        errors, warnings = process_file_data(df, dataset, row_number, overwrite)
         error_logs = error_logs + errors
         warning_logs = warning_logs + warnings
         row_number = row_number + chunksize
@@ -55,7 +55,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     filename = dataset_file.document.name
     chunksize = getattr(settings, "CHUNK_SIZE_LIMIT", 1000000)
-    reset_datasetdata = kwargs.get("reset", False)
+    overwrite = kwargs.get("overwrite", False)
     logger.debug(f"Processing: {filename}")
 
     columns = None
@@ -65,7 +65,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
 
     if ".csv" in filename:
         logger.debug(f"Processing as csv")
-        csv_output = process_csv(dataset, dataset_file.document.open("rb"), reset_datasetdata, chunksize)
+        csv_output = process_csv(dataset, dataset_file.document.open("rb"), overwrite, chunksize)
         error_logs = csv_output["error_logs"]
         warning_logs = csv_output["warning_logs"]
         columns = csv_output["columns"]
@@ -87,7 +87,7 @@ def process_uploaded_file(dataset_file, dataset, **kwargs):
             else:
                 df.dropna(how='any', axis='columns', inplace=True)
                 df.columns = columns
-                errors, warnings = process_file_data(df, dataset, row_number, reset_datasetdata)
+                errors, warnings = process_file_data(df, dataset, row_number, overwrite)
                 error_logs = error_logs + errors
                 warning_logs = warning_logs + warnings
                 row_number = row_number + chunksize

--- a/wazimap_ng/datasets/views.py
+++ b/wazimap_ng/datasets/views.py
@@ -97,7 +97,7 @@ def dataset_upload(request, dataset_id):
     update_indicators = request.POST.get('update', False)
     upload_task = async_task(
         "wazimap_ng.datasets.tasks.process_uploaded_file",
-        datasetfile_obj, dataset,
+        datasetfile_obj, dataset, reset=True,
         task_name=f"Uploading data: {dataset.name}",
         hook="wazimap_ng.datasets.hooks.process_task_info",
         key=request.session.session_key,

--- a/wazimap_ng/datasets/views.py
+++ b/wazimap_ng/datasets/views.py
@@ -99,7 +99,7 @@ def dataset_upload(request, dataset_id):
 
     upload_task = async_task(
         "wazimap_ng.datasets.tasks.process_uploaded_file",
-        datasetfile_obj, dataset, reset=overwrite,
+        datasetfile_obj, dataset, overwrite=overwrite,
         task_name=f"Uploading data: {dataset.name}",
         hook="wazimap_ng.datasets.hooks.process_task_info",
         key=request.session.session_key,

--- a/wazimap_ng/datasets/views.py
+++ b/wazimap_ng/datasets/views.py
@@ -95,9 +95,11 @@ def dataset_upload(request, dataset_id):
         dataset_id=dataset.id
     )
     update_indicators = request.POST.get('update', False)
+    overwrite = request.POST.get('overwrite', False)
+
     upload_task = async_task(
         "wazimap_ng.datasets.tasks.process_uploaded_file",
-        datasetfile_obj, dataset, reset=True,
+        datasetfile_obj, dataset, reset=overwrite,
         task_name=f"Uploading data: {dataset.name}",
         hook="wazimap_ng.datasets.hooks.process_task_info",
         key=request.session.session_key,


### PR DESCRIPTION
## Description
Added a way so we can reset dataset data in upload load data.
It's better to do this delete in loaddata because it's an atomic transaction where data is created so it will only delete data if newly uploaded is added to dataset data without any error.

## Related Issue
#238 

## How to test it locally
Reupload same file for a dataset from postman and check if there is duplicate data in indicator data.
Second way to test is if reset is set to true than Django Q logger will have a log statement of : `Deleting previously uploaded data for this dataset`

This statement will not be printed when data is uploaded via admin.
and will also have duplicate indicator data.

## Changelog
Added reset key to loaddata and process_uploaded_file task so we can send reset True or False from async_task to task function.

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
