### PR TITLE
Added last_updated_at in all_details api endpoint for profile indicator data

### DIFF
--- a/wazimap_ng/profile/serializers/indicator_data_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer.py
@@ -44,7 +44,8 @@ def get_indicator_data(profile, indicators, geographies):
                 licence_name=F("indicator__dataset__metadata__licence__name"),
                 indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
                 geography_code=F("geography__code"),
-                primary_group=F("indicator__groups")
+                primary_group=F("indicator__groups"),
+                last_updated_at=F("indicator__profileindicator__updated"),
             )
             .order_by("indicator__profileindicator__order")
             )
@@ -110,6 +111,7 @@ def IndicatorDataSerializer(profile, geography):
                                  "id": x["profile_indicator_id"],
                                  "description": x["description"],
                                  "choropleth_method": x["choropleth_method"],
+                                 "last_updated_at": x["last_updated_at"],
                                  "metadata": {
                                      "source": x["metadata_source"],
                                      "description": x["metadata_description"],


### PR DESCRIPTION

## Description
Added `last_updated_at` in all_detail api endpoint.

## Related Issue
#239

## How to test it locally
Change can be seen on api endpoint : `http://localhost:8000/api/v1/all_details/profile/1/geography/ZA/?format=json`

## Changelog
added last_updated_at field in indicator_data_serializer in profile/serializers

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
