### PR TITLE
chore: add tests for profile theme order issue

### DIFF
--- a/tests/points/factories.py
+++ b/tests/points/factories.py
@@ -13,6 +13,7 @@ class ThemeFactory(factory.django.DjangoModelFactory):
 
     profile = factory.SubFactory(ProfileFactory)
     name = "Theme"
+    order = factory.Sequence(lambda n: n)
 
 
 class CategoryFactory(factory.django.DjangoModelFactory):

--- a/tests/points/test_views.py
+++ b/tests/points/test_views.py
@@ -261,3 +261,20 @@ class TestLocationView(APITestCase):
         assert len(results[1]["features"]) == 1
         assert results[1]["features"][0]["geometry"]["coordinates"] == [2.0, 2.0]
         assert results[1]["category"] == "Pc Label 2"
+
+@pytest.mark.focus
+@pytest.mark.django_db
+class TestPointThemes:
+    def test_order_themes(self, tp, tp_api):
+        profile = ProfileFactory()
+        theme2 = ThemeFactory(order=2, profile=profile)
+        theme1 = ThemeFactory(order=1, profile=profile)
+
+        reversed_url = tp.reverse('points-themes', profile_id=profile.pk)
+        response = tp_api.client.get(reversed_url, format="json")
+
+        assert response.status_code == 200
+        js_data = response.json()
+        assert js_data[0]["id"] == theme1.id
+        assert js_data[1]["id"] == theme2.id
+


### PR DESCRIPTION
## Description
the ordering of the themes seems to be off, but this tests shows that is
has nothing to do with the current serializer or implementation, likely
some othe issue

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
