### PR TITLE
Filter current dataset subindicators

### DIFF
--- a/tests/datasets/test_dataloader.py
+++ b/tests/datasets/test_dataloader.py
@@ -265,37 +265,42 @@ class TestCreateGroups:
         assert groups[1].subindicators == ["X", "Y"]
 
     def test_new_dataset_same_group_name(self, dataset, datasetData, subindicatorGroup):
-        # Make sure datasets with new subindicators are not leaking into groups with the same name from previous datasets
+        # Make sure new datasets with the same group name do not have subindicators from previous datasets
         new_dataset = DatasetFactory()
 
         DatasetDataFactory(
             dataset=new_dataset, data={
-                'group1': 'D', 'group2': 'Z'
+                'group1': 'C', 'group2': 'Z'
             }
         )
 
         groups = dataloader.create_groups(new_dataset, ["group1", "group2"])
 
         assert len(groups) == 2
-        assert groups[0].subindicators == ["D"]
-        assert groups[0].subindicators != ["A", "B", "C", "D"]
+        assert groups[0].subindicators == ["C"]
+        assert groups[0].subindicators != ["A", "B", "C"]
         assert groups[1].subindicators == ["Z"]
         assert groups[1].subindicators != ["X", "Y", "Z"]
 
     def test_old_dataset_does_not_include_new_subindicators(self, dataset, datasetData, subindicatorGroup):
         # Make sure same group names from a previous dataset does not have subindicators leaking into it
+        new_dataset = DatasetFactory()
 
         DatasetDataFactory(
-            dataset=dataset, data={
-                'group1': 'C', 'group2': 'Z'
+            dataset=new_dataset, data={
+                'group1': 'D', 'group2': 'W'
             }
         )
 
+        new_groups = dataloader.create_groups(new_dataset, ["group1", "group2"])
         groups = dataloader.create_groups(dataset, ["group1", "group2"])
 
         assert len(groups) == 2
-        assert groups[0].subindicators == ["A", "B", "C"]
+        assert new_groups[0].subindicators == ["D"]
+        assert new_groups[1].subindicators == ["W"]
+
+        assert groups[0].subindicators == ["A", "B"]
         assert groups[0].subindicators != ["D"]
-        assert groups[1].subindicators == ["X", "Y", "Z"]
-        assert groups[1].subindicators != ["Z"]
+        assert groups[1].subindicators == ["X", "Y"]
+        assert groups[1].subindicators != ["W"]
 

--- a/tests/datasets/test_dataloader.py
+++ b/tests/datasets/test_dataloader.py
@@ -263,3 +263,19 @@ class TestCreateGroups:
         assert len(groups) == 2
         assert groups[0].subindicators == ["A", "B", "C"]
         assert groups[1].subindicators == ["X", "Y"]
+
+    def test_new_dataset(self, dataset, datasetData, subindicatorGroup):
+        dataset = DatasetFactory()
+
+        DatasetDataFactory(
+            dataset=dataset, data={
+                'group1': 'D', 'group2': 'Z'
+            }
+        )
+
+        groups = dataloader.create_groups(dataset, ["group1", "group2"])
+
+        assert len(groups) == 2
+        assert groups[0].subindicators == ["D"]
+        assert groups[1].subindicators == ["Z"]
+

--- a/tests/datasets/test_dataloader.py
+++ b/tests/datasets/test_dataloader.py
@@ -264,7 +264,8 @@ class TestCreateGroups:
         assert groups[0].subindicators == ["A", "B", "C"]
         assert groups[1].subindicators == ["X", "Y"]
 
-    def test_new_dataset(self, dataset, datasetData, subindicatorGroup):
+    def test_new_dataset_subindicators(self, dataset, datasetData, subindicatorGroup):
+        # Re-instantiate DatasetFactory to get a new dataset ID, create groups with unique subindicators and check that only subindicators from this dataset exist
         dataset = DatasetFactory()
 
         DatasetDataFactory(

--- a/wazimap_ng/datasets/dataloader.py
+++ b/wazimap_ng/datasets/dataloader.py
@@ -20,7 +20,7 @@ def load_geography(geo_code, version):
 def create_groups(dataset, group_names):
     groups = []
     for g in group_names:
-        subindicators = list(models.DatasetData.objects.get_unique_subindicators(g))
+        subindicators = list(models.DatasetData.objects.filter(dataset_id=dataset.id).get_unique_subindicators(g))
 
         group, created = models.Group.objects.get_or_create(
             name=g, dataset=dataset


### PR DESCRIPTION
This will only fetch/create sub-indicators for filter values from the current dataset

## Description


## Related Issue
https://github.com/OpenUpSA/wazimap-ng-ui/issues/346
https://trello.com/c/SWt9HuT3/733-productionise-vega-and-data-branch

## How to test it locally
Upload a dataset and check if group ordering contains unexpected filter values

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
