### PR TITLE
Constrain memory during migration

### DIFF
--- a/wazimap_ng/config/qcluster.py
+++ b/wazimap_ng/config/qcluster.py
@@ -16,4 +16,5 @@ class QCluster:
     Q_CLUSTER = {
         "redis": os.environ.get("REDIS_URL"),
         "workers": int(os.environ.get("Q_CLUSTER_WORKERS", 4)),
+        "recycle": int(os.environ.get("Q_CLUSTER_RECYCLE", 10)),
     }

--- a/wazimap_ng/config/qcluster.py
+++ b/wazimap_ng/config/qcluster.py
@@ -14,5 +14,6 @@ class QCluster:
     # }
 
     Q_CLUSTER = {
-        "redis": os.environ.get("REDIS_URL")
+        "redis": os.environ.get("REDIS_URL"),
+        "workers": int(os.environ.get("Q_CLUSTER_WORKERS", 4)),
     }


### PR DESCRIPTION
## Description

Reprocessing 450 tasks caused hetzner1 to run out of its remaining 30GB of memory.

We need to stop memory consumption from growing beyond what we can keep free on the server.

This allows us to 

1. restart worker processes more frequently, forcing garbage collection
2. limit the number of workers running concurrently, each consuming a bunch of memory

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
