### PR TITLE
Update Django-Q to version that fixes the SSL errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ djangorestframework-gis==0.14
 Fiona==1.8.13.post1
 Shapely==1.6.4
 
-django-q==1.3.1
+django-q==1.3.6
 redis==3.5.3
 
 # Data manipulation


### PR DESCRIPTION
## Description

We've been getting lots of `SSL error: decryption failed or bad record mac` errors from async tasks.

This has been fixed in https://github.com/Koed00/django-q/pull/556 which is included in 1.3.6

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
