### PR TITLE
Check if geography indicator exists before using it

### DIFF
--- a/tests/profile/serializers/test_metrics_serializer.py
+++ b/tests/profile/serializers/test_metrics_serializer.py
@@ -27,4 +27,14 @@ def test_sibling(profile_key_metric, geography, other_geographies):
         expected_value = 1 / num_geographies
         actual_value = sibling(profile_key_metric, geography)
         assert pytest.approx(expected_value, abs=1e-1) == actual_value
-    
+
+
+@pytest.mark.django_db
+def test_subindicator_geography(profile_key_metric, geography, other_geographies):
+    # Check that a subindicator exists for the given geography before trying to access it
+    subindicator_data = subindicator(profile_key_metric, geography)
+    subindicator_none = subindicator(profile_key_metric, other_geographies[0])
+
+    assert type(subindicator_data) == type(0.1)
+    assert subindicator_none == None
+

--- a/tests/profile/serializers/test_metrics_serializer.py
+++ b/tests/profile/serializers/test_metrics_serializer.py
@@ -30,11 +30,14 @@ def test_sibling(profile_key_metric, geography, other_geographies):
 
 
 @pytest.mark.django_db
-def test_subindicator_geography(profile_key_metric, geography, other_geographies):
-    # Check that a subindicator exists for the given geography before trying to access it
+def test_subindicator_not_none(profile_key_metric, geography):
+    # Check expected function of subindicator that it returns some value
     subindicator_data = subindicator(profile_key_metric, geography)
-    subindicator_none = subindicator(profile_key_metric, other_geographies[0])
+    assert subindicator_data != None
 
-    assert type(subindicator_data) == type(0.1)
-    assert subindicator_none == None
+@pytest.mark.django_db
+def test_subindicator_none(profile_key_metric, other_geographies):
+    # Check that an incorrect geography, without a subindicator returns None
+    subindicator_data = subindicator(profile_key_metric, other_geographies[0])
+    assert subindicator_data == None
 

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -16,8 +16,11 @@ def absolute_value(profile_key_metric, geography):
     return MetricCalculator.absolute_value(data, profile_key_metric, geography)
 
 def subindicator(profile_key_metric, geography):
-    data = get_indicator_data(profile_key_metric, [geography]).first().data
-    return MetricCalculator.subindicator(data, profile_key_metric, geography)
+    indicator_data = IndicatorData.objects.filter(indicator__profilekeymetrics=profile_key_metric, geography=geography)
+    if indicator_data.count() > 0:
+        data = get_indicator_data(profile_key_metric, [geography]).first().data
+        return MetricCalculator.subindicator(data, profile_key_metric, geography)
+    return None
 
 def sibling(profile_key_metric, geography):
     siblings = geography.get_siblings()

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -16,9 +16,9 @@ def absolute_value(profile_key_metric, geography):
     return MetricCalculator.absolute_value(data, profile_key_metric, geography)
 
 def subindicator(profile_key_metric, geography):
-    indicator_data = IndicatorData.objects.filter(indicator__profilekeymetrics=profile_key_metric, geography=geography)
+    indicator_data = get_indicator_data(profile_key_metric, [geography])
     if indicator_data.count() > 0:
-        data = get_indicator_data(profile_key_metric, [geography]).first().data
+        data = indicator_data.first().data
         return MetricCalculator.subindicator(data, profile_key_metric, geography)
     return None
 


### PR DESCRIPTION
## Description
Check that a subindicator data point exists before trying to use it

## Related Issue
https://github.com/OpenUpSA/wazimap-ng/issues/287

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
