### PR TITLE
Fix issue of duplicate subindicators

### DIFF
--- a/wazimap_ng/profile/serializers/indicator_data_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer.py
@@ -63,8 +63,7 @@ def get_dataset_groups(profile: Profile) -> Dict:
             "name",
             "can_aggregate",
             "can_filter"
-        )
-        .order_by("dataset")
+        ).order_by("id").distinct("id")
     )
 
     grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])


### PR DESCRIPTION
## Description
Issue was because of duplicate subindicators in the api due to multiple profile indicator using same dataset.

## Related Issue
Trello issue : https://trello.com/c/pTYHkYFv/769-duplication-of-filter-attribute-options

## How to test it locally
visit all_detail api endpoint.
Inside groups there are subindicators.
create a new profile indicator with same dataset as in the subindicator.
Now you will see there are multiple subindicators with same name here.

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
