### PR TITLE
Fix: Key Metric serialiser on missing geography

### DIFF
--- a/tests/profile/serializers/test_metrics_serializer.py
+++ b/tests/profile/serializers/test_metrics_serializer.py
@@ -35,15 +35,21 @@ def test_subindicator_not_none(profile_key_metric, geography):
     subindicator_data = subindicator(profile_key_metric, geography)
     assert subindicator_data != None
 
-    absolute_value_data = absolute_value(profile_key_metric, geography)
-    assert absolute_value_data != None
-
 @pytest.mark.django_db
 def test_subindicator_none(profile_key_metric, other_geographies):
     # Check that an incorrect geography, without a subindicator returns None
     subindicator_data = subindicator(profile_key_metric, other_geographies[0])
     assert subindicator_data == None
 
+@pytest.mark.django_db
+def test_absolute_value_not_none(profile_key_metric, geography):
+    # Check expected function of absolute_value that it returns some value
+    absolute_value_data = absolute_value(profile_key_metric, geography)
+    assert absolute_value_data != None
+
+@pytest.mark.django_db
+def test_absolute_value_none(profile_key_metric, other_geographies):
+    # Check that an incorrect geography, without a subindicator returns None
     absolute_value_data = absolute_value(profile_key_metric, other_geographies[0])
     assert absolute_value_data == None
 

--- a/tests/profile/serializers/test_metrics_serializer.py
+++ b/tests/profile/serializers/test_metrics_serializer.py
@@ -35,9 +35,15 @@ def test_subindicator_not_none(profile_key_metric, geography):
     subindicator_data = subindicator(profile_key_metric, geography)
     assert subindicator_data != None
 
+    absolute_value_data = absolute_value(profile_key_metric, geography)
+    assert absolute_value_data != None
+
 @pytest.mark.django_db
 def test_subindicator_none(profile_key_metric, other_geographies):
     # Check that an incorrect geography, without a subindicator returns None
     subindicator_data = subindicator(profile_key_metric, other_geographies[0])
     assert subindicator_data == None
+
+    absolute_value_data = absolute_value(profile_key_metric, other_geographies[0])
+    assert absolute_value_data == None
 

--- a/tests/profile/serializers/test_metrics_serializer.py
+++ b/tests/profile/serializers/test_metrics_serializer.py
@@ -53,3 +53,11 @@ def test_absolute_value_none(profile_key_metric, other_geographies):
     absolute_value_data = absolute_value(profile_key_metric, other_geographies[0])
     assert absolute_value_data == None
 
+@pytest.mark.django_db
+@pytest.mark.usefixtures("other_geographies_indicatordata")
+def test_sibling_not_none(profile_key_metric, geography, other_geographies):
+    # Check expected function of sibling that it returns some value
+    with patch.object(geography, "get_siblings", side_effect=lambda: other_geographies):
+        sibling_data = sibling(profile_key_metric, geography)
+        assert sibling_data != None
+

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -12,8 +12,11 @@ def get_indicator_data(profile_key_metric, geographies):
 
 
 def absolute_value(profile_key_metric, geography):
-    data = get_indicator_data(profile_key_metric, [geography]).first().data
-    return MetricCalculator.absolute_value(data, profile_key_metric, geography)
+    indicator_data = get_indicator_data(profile_key_metric, [geography])
+    if indicator_data.count() > 0:
+        data = indicator_data.first().data
+        return MetricCalculator.absolute_value(data, profile_key_metric, geography)
+    return None
 
 def subindicator(profile_key_metric, geography):
     indicator_data = get_indicator_data(profile_key_metric, [geography])

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -19,7 +19,7 @@ def indicator_exists(profile_key_metric, geographies):
 def absolute_value(profile_key_metric, geography):
     indicator_data = indicator_exists(profile_key_metric, [geography])
     if indicator_data != None:
-        return MetricCalculator.absolute_value(data, profile_key_metric, geography)
+        return MetricCalculator.absolute_value(indicator_data, profile_key_metric, geography)
     return None
 
 def subindicator(profile_key_metric, geography):

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -10,19 +10,22 @@ def get_indicator_data(profile_key_metric, geographies):
     indicator_data = IndicatorData.objects.filter(indicator__profilekeymetrics=profile_key_metric, geography__in=geographies)
     return indicator_data
 
+def indicator_exists(profile_key_metric, geographies):
+    indicator_data = get_indicator_data(profile_key_metric, geographies)
+    if indicator_data.count() > 0:
+        return indicator_data.first().data
+    return None
 
 def absolute_value(profile_key_metric, geography):
-    indicator_data = get_indicator_data(profile_key_metric, [geography])
-    if indicator_data.count() > 0:
-        data = indicator_data.first().data
+    indicator_data = indicator_exists(profile_key_metric, [geography])
+    if indicator_data != None:
         return MetricCalculator.absolute_value(data, profile_key_metric, geography)
     return None
 
 def subindicator(profile_key_metric, geography):
-    indicator_data = get_indicator_data(profile_key_metric, [geography])
-    if indicator_data.count() > 0:
-        data = indicator_data.first().data
-        return MetricCalculator.subindicator(data, profile_key_metric, geography)
+    indicator_data = indicator_exists(profile_key_metric, [geography])
+    if indicator_data != None:
+        return MetricCalculator.subindicator(indicator_data, profile_key_metric, geography)
     return None
 
 def sibling(profile_key_metric, geography):

--- a/wazimap_ng/profile/serializers/metrics_serializer.py
+++ b/wazimap_ng/profile/serializers/metrics_serializer.py
@@ -10,20 +10,20 @@ def get_indicator_data(profile_key_metric, geographies):
     indicator_data = IndicatorData.objects.filter(indicator__profilekeymetrics=profile_key_metric, geography__in=geographies)
     return indicator_data
 
-def indicator_exists(profile_key_metric, geographies):
+def get_data_for_key_metric_and_geographies(profile_key_metric, geographies):
     indicator_data = get_indicator_data(profile_key_metric, geographies)
     if indicator_data.count() > 0:
         return indicator_data.first().data
     return None
 
 def absolute_value(profile_key_metric, geography):
-    indicator_data = indicator_exists(profile_key_metric, [geography])
+    indicator_data = get_data_for_key_metric_and_geographies(profile_key_metric, [geography])
     if indicator_data != None:
         return MetricCalculator.absolute_value(indicator_data, profile_key_metric, geography)
     return None
 
 def subindicator(profile_key_metric, geography):
-    indicator_data = indicator_exists(profile_key_metric, [geography])
+    indicator_data = get_data_for_key_metric_and_geographies(profile_key_metric, [geography])
     if indicator_data != None:
         return MetricCalculator.subindicator(indicator_data, profile_key_metric, geography)
     return None
@@ -31,7 +31,9 @@ def subindicator(profile_key_metric, geography):
 def sibling(profile_key_metric, geography):
     siblings = geography.get_siblings()
     data = get_indicator_data(profile_key_metric, [geography] + siblings)
-    return MetricCalculator.sibling(data, profile_key_metric, geography)
+    if data.count() > 0:
+        return MetricCalculator.sibling(data, profile_key_metric, geography)
+    return None
 
 algorithms = {
     "absolute_value": absolute_value,


### PR DESCRIPTION
## Description
There was an issue where a geography would try to access sub-indicators that did not exist

## Related Issue
Closes #291 

## How to test it locally

## Changelog

### Added

### Updated
Fixed cases where the backend crashed if a geography had empty sub-indicators

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
