### PR TITLE
Added a management command to reprocess indicators

### DIFF
--- a/tests/datasets/management/test_reprocess_indicators.py
+++ b/tests/datasets/management/test_reprocess_indicators.py
@@ -1,0 +1,26 @@
+import pytest
+from django.core.management import call_command
+from django_q.models import Task
+from wazimap_ng.datasets.models import Indicator
+from wazimap_ng.datasets.management.commands import reprocess_indicators
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("indicator")
+class TestReprocessIndicators:
+
+    def test_reprocess_indicators(self):
+        args = []
+        opts = {}
+        assert Task.objects.filter(success=True).count() == 0
+        assert Indicator.objects.count() == 1
+        indicator_obj = Indicator.objects.first()
+
+        reprocess_indicators.input = lambda x: 'yes'
+        call_command('reprocess_indicators', *args, **opts)
+
+        assert Task.objects.filter(success=True).count() == 1
+        task = Task.objects.filter(success=True).first()
+        assert task.args[0] == indicator_obj
+        assert task.kwargs["type"] == "data_extraction"
+
+

--- a/wazimap_ng/datasets/management/commands/reprocess_indicators.py
+++ b/wazimap_ng/datasets/management/commands/reprocess_indicators.py
@@ -3,78 +3,17 @@ import sys
 from django.core.management.base import BaseCommand, CommandError
 
 from ...models import Indicator
-from django.contrib.auth.models import User
 from django_q.tasks import async_task
-from django_q.brokers import get_broker
-from django_q.models import Task
 
 
 class Command(BaseCommand):
     help = 'Rerun indicator data process for variables'
 
-    def add_arguments(self, parser):
-        parser.add_argument(
-            '--variables', nargs='+', type=int, default=[],
-            help="pass variable ids to process : --variables 1 2 3"
-        )
-        parser.add_argument(
-            '--datasets', nargs='+', type=int, default=[],
-            help="pass dataset ids to process linked variables : --datasets 1 2 3"
-        )
-        parser.add_argument(
-            '--profiles', nargs='+', type=int, default=[],
-            help="pass profile ids to process linked variables : --profiles 1 2 3"
-        )
-        parser.add_argument(
-            '--user_id', nargs=1, type=int,
-            help="pass user id to get fail task notification : --user_id 2"
-        )
-        parser.add_argument(
-            '--rerun_failed', nargs=1, type=int,
-            help="rerun all failed tasks for extraction-ID group : --rerun_failed 20"
-        )
-
-
     def handle(self, *args, **options):
-        to_update = options['variables']
-        datasets = options['datasets']
-        profiles = options['profiles']
-        user_id = options['user_id']
-        rerun_failed = options['rerun_failed']
-        email_on_fail = True if user_id else False
-        user = None
-
-        if user_id:
-            user_id = user_id[0]
-            user = User.objects.filter(id=user_id).first()
-            if not user:
-                print(F"User with user id {user_id} does not exist")
-                sys.exit()
-
-        if datasets:
-            to_update = list(Indicator.objects.filter(
-                dataset_id__in=datasets
-            ).values_list("id", flat=True)) + to_update
-
-        if profiles:
-            to_update = list(Indicator.objects.filter(
-                dataset__profile_id__in=profiles
-            ).values_list("id", flat=True)) + to_update
-
-        if rerun_failed:
-            to_update = to_update + [t.args[0].id for t in Task.objects.filter(
-                group=f"extraction-{rerun_failed[0]}", success=False
-            )]
-
-        variables = Indicator.objects.all()
-        if to_update:
-            variables = variables.filter(
-                id__in=list(set(to_update))
-            )
-
         yes = ['y', 'yes', 'ye']
         no = ['no', 'n']
         continue_process = False
+        variables = Indicator.objects.all()
 
         while True:
             confirmation = input(F'Do you want to re run data extraction for {variables.count()} variables? [y/n]').lower()
@@ -85,39 +24,11 @@ class Command(BaseCommand):
                 break  
 
         if continue_process:
-
-            group_id = 1
-            group_ids = Task.objects.filter(
-                group__contains="extraction"
-            ).values_list("group", flat=True).order_by("-group").distinct("group")
-
-            if group_ids:
-                group_ids = [int(g.split("-")[1]) for g in group_ids]
-                group_ids.sort(reverse=True)
-                group_id = group_ids[0] + group_id
-            
-            print("="*100)
-            print("Info:\n")
-            if not user_id:
-                print('* Email notification for failed task are not enabled')
-            else:
-                print(F'* Email notifications for failed tasks will be sent to {user.email}')
-
-            print(F"* Total number for variables to be processed: {variables.count()}")
-            print(F"* Id to recheck tasks ran in this instance: {group_id}")
-            print("="*100)
-
             for variable in variables:
                 async_task(
                     "wazimap_ng.datasets.tasks.indicator_data_extraction",
                     variable,
                     task_name=f"Migration Data Extraction: {variable.id} {variable.name}",
                     hook="wazimap_ng.datasets.hooks.process_task_info",
-                    group=F"extraction-{group_id}",
-                    type="data_extraction", assign=False, notify=False, user_id=user_id,
-                    email_on_fail=True if user_id else False
+                    type="data_extraction", assign=False, notify=False
                 )
-
-            
-                        
-

--- a/wazimap_ng/datasets/management/commands/reprocess_indicators.py
+++ b/wazimap_ng/datasets/management/commands/reprocess_indicators.py
@@ -1,0 +1,123 @@
+import sys
+
+from django.core.management.base import BaseCommand, CommandError
+
+from ...models import Indicator
+from django.contrib.auth.models import User
+from django_q.tasks import async_task
+from django_q.brokers import get_broker
+from django_q.models import Task
+
+
+class Command(BaseCommand):
+    help = 'Rerun indicator data process for variables'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--variables', nargs='+', type=int, default=[],
+            help="pass variable ids to process : --variables 1 2 3"
+        )
+        parser.add_argument(
+            '--datasets', nargs='+', type=int, default=[],
+            help="pass dataset ids to process linked variables : --datasets 1 2 3"
+        )
+        parser.add_argument(
+            '--profiles', nargs='+', type=int, default=[],
+            help="pass profile ids to process linked variables : --profiles 1 2 3"
+        )
+        parser.add_argument(
+            '--user_id', nargs=1, type=int,
+            help="pass user id to get fail task notification : --user_id 2"
+        )
+        parser.add_argument(
+            '--rerun_failed', nargs=1, type=int,
+            help="rerun all failed tasks for extraction-ID group : --rerun_failed 20"
+        )
+
+
+    def handle(self, *args, **options):
+        to_update = options['variables']
+        datasets = options['datasets']
+        profiles = options['profiles']
+        user_id = options['user_id']
+        rerun_failed = options['rerun_failed']
+        email_on_fail = True if user_id else False
+        user = None
+
+        if user_id:
+            user_id = user_id[0]
+            user = User.objects.filter(id=user_id).first()
+            if not user:
+                print(F"User with user id {user_id} does not exist")
+                sys.exit()
+
+        if datasets:
+            to_update = list(Indicator.objects.filter(
+                dataset_id__in=datasets
+            ).values_list("id", flat=True)) + to_update
+
+        if profiles:
+            to_update = list(Indicator.objects.filter(
+                dataset__profile_id__in=profiles
+            ).values_list("id", flat=True)) + to_update
+
+        if rerun_failed:
+            to_update = to_update + [t.args[0].id for t in Task.objects.filter(
+                group=f"extraction-{rerun_failed[0]}", success=False
+            )]
+
+        variables = Indicator.objects.all()
+        if to_update:
+            variables = variables.filter(
+                id__in=list(set(to_update))
+            )
+
+        yes = ['y', 'yes', 'ye']
+        no = ['no', 'n']
+        continue_process = False
+
+        while True:
+            confirmation = input(F'Do you want to re run data extraction for {variables.count()} variables? [y/n]').lower()
+            if confirmation in no:
+                break
+            elif confirmation in yes:
+                continue_process = True
+                break  
+
+        if continue_process:
+
+            group_id = 1
+            group_ids = Task.objects.filter(
+                group__contains="extraction"
+            ).values_list("group", flat=True).order_by("-group").distinct("group")
+
+            if group_ids:
+                group_ids = [int(g.split("-")[1]) for g in group_ids]
+                group_ids.sort(reverse=True)
+                group_id = group_ids[0] + group_id
+            
+            print("="*100)
+            print("Info:\n")
+            if not user_id:
+                print('* Email notification for failed task are not enabled')
+            else:
+                print(F'* Email notifications for failed tasks will be sent to {user.email}')
+
+            print(F"* Total number for variables to be processed: {variables.count()}")
+            print(F"* Id to recheck tasks ran in this instance: {group_id}")
+            print("="*100)
+
+            for variable in variables:
+                async_task(
+                    "wazimap_ng.datasets.tasks.indicator_data_extraction",
+                    variable,
+                    task_name=f"Migration Data Extraction: {variable.id} {variable.name}",
+                    hook="wazimap_ng.datasets.hooks.process_task_info",
+                    group=F"extraction-{group_id}",
+                    type="data_extraction", assign=False, notify=False, user_id=user_id,
+                    email_on_fail=True if user_id else False
+                )
+
+            
+                        
+


### PR DESCRIPTION
## Description
Added a management command to reprocess indicators
Options:
* `--variables :  pass variable ids to process`
* `--datasets : pass dataset ids to process linked variables`
* `--profiles : pass profile ids to process linked variable`
* `--user_id : pass user id to get fail task notification`
* `--rerun_failed : rerun all failed tasks for extraction-ID group which will be created when we run task`
* If no option for variable, dataset & profiles is passed script will run for all existing variables

## Related Issue
https://trello.com/c/qj0bFZj5/778-reprocess-indicators-as-a-sysadmin-i-would-like-to-be-able-to-re-process-indicator-data-so-that-changes-to-the-data-format-can-b


## How to test it locally
run management command : `docker exec -it wazimap-ng_web_1 python3 manage.py reprocess_indicators --variables 20 21 22 28 29 40 45 46`

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
