### PR TITLE
fix: disable 1970 date when no cache key is found

### DIFF
--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -36,13 +36,11 @@ def check_has_permission(request, profile_id):
 
 def last_modified(request, profile_id, key):
     if check_has_permission(request, profile_id):
-        _last_modified = datetime(year=1970, month=1, day=1)
+        _last_modified = datetime.now()
         c = cache.get(key)
 
         if c is not None:
             return c
-        else:
-            return datetime.now()
     else:
         _last_modified = datetime.now()
     return _last_modified

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -41,6 +41,8 @@ def last_modified(request, profile_id, key):
 
         if c is not None:
             return c
+        else:
+            return datetime.now()
     else:
         _last_modified = datetime.now()
     return _last_modified
@@ -190,7 +192,7 @@ def geography_updated(sender, instance, **kwargs):
         "indicator__dataset__profile", flat=True
     ).order_by("indicator__dataset__profile").distinct())
 
-    # Get hierarchy profile linked to 
+    # Get hierarchy profile linked to
     hierarchy_profile_ids = list(instance.geographyhierarchy_set.values_list(
         "profile", flat=True
     ).order_by("profile").distinct())


### PR DESCRIPTION
## Description
return current date when no cache key is found

![Screenshot from 2021-06-09 11-08-02](https://user-images.githubusercontent.com/6994982/121317479-00ce1700-c913-11eb-9dc3-48fdf0666d6e.png)


## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
