### PR TITLE
Allow user to quickly find the subindicator group for a specific profile indicator

### DIFF
--- a/wazimap_ng/datasets/templates/admin/datasets/dataset/change_form.html
+++ b/wazimap_ng/datasets/templates/admin/datasets/dataset/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+<div>
+  <h2>Dataset Resources</h2>
+  <h3>Subindicator groups</h3>
+  <table>
+    {% for group in original.group_set.all %}
+    <tr>
+      <td><a href="{% url 'admin:datasets_group_change' group.pk %}">{{ group.name }}</a></td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}

--- a/wazimap_ng/datasets/templates/admin/datasets/indicator/change_form.html
+++ b/wazimap_ng/datasets/templates/admin/datasets/indicator/change_form.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+<div>
+  <h2>Variable Resources</h2>
+  <a href="{% url 'admin:datasets_dataset_change' original.dataset.pk %}">
+    View/edit dataset
+  </a>
+</div>
+{% endblock %}

--- a/wazimap_ng/profile/templates/admin/profile/indicatorcategory/change_form.html
+++ b/wazimap_ng/profile/templates/admin/profile/indicatorcategory/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+<div>
+  <h2>Indicator Category Resources</h2>
+  <h3>Indicator subcategories</h3>
+  <table>
+    {% for subcategory in original.indicatorsubcategory_set.all %}
+    <tr>
+      <td><a href="{% url 'admin:profile_indicatorsubcategory_change' subcategory.pk %}">{{ subcategory.name }}</a></td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}

--- a/wazimap_ng/profile/templates/admin/profile/indicatorsubcategory/change_form.html
+++ b/wazimap_ng/profile/templates/admin/profile/indicatorsubcategory/change_form.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+<div>
+  <h2>Indicator Subcateogry Resources</h2>
+  <h3>Profile indicators</h3>
+  <table>
+    {% for profileindicator in original.profileindicator_set.all %}
+    <tr>
+      <td><a href="{% url 'admin:profile_profileindicator_change' profileindicator.pk %}">{{ profileindicator.label }}</a></td>
+      <td>{{ profileindicator.profile.name }}</td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}

--- a/wazimap_ng/profile/templates/admin/profile/profile/change_form.html
+++ b/wazimap_ng/profile/templates/admin/profile/profile/change_form.html
@@ -1,0 +1,15 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+<div>
+  <h2>Profile Resources</h2>
+  <h3>Indicator categories</h3>
+  <table>
+    {% for category in original.indicatorcategory_set.all %}
+    <tr>
+      <td><a href="{% url 'admin:profile_indicatorcategory_change' category.pk %}">{{ category.name }}</a></td>
+    </tr>
+    {% endfor %}
+  </table>
+</div>
+{% endblock %}

--- a/wazimap_ng/profile/templates/admin/profile/profileindicator/change_form.html
+++ b/wazimap_ng/profile/templates/admin/profile/profileindicator/change_form.html
@@ -1,0 +1,10 @@
+{% extends "admin/change_form.html" %}
+{% block content %}
+{{ block.super }}
+<div>
+  <h2>Profile Indicator Resources</h2>
+  <a href="{% url 'admin:datasets_indicator_change' original.indicator.pk %}">
+    View/edit variable
+  </a>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Description

allow an admin to navigate profile resources as it's structured in the actual site.

See next comment with screenshots in reverse order

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
