### PR TITLE
Removed universe from read only fields for variable admin

### DIFF
--- a/wazimap_ng/datasets/admin/indicator_admin.py
+++ b/wazimap_ng/datasets/admin/indicator_admin.py
@@ -65,7 +65,7 @@ class IndicatorAdmin(DatasetBaseAdminModel):
 
     def get_readonly_fields(self, request, obj=None):
         if obj:
-            to_add = ('dataset',"groups", "universe",)
+            to_add = ('dataset',"groups",)
             return self.readonly_fields + to_add
         return self.readonly_fields
 


### PR DESCRIPTION
## Description

Removed universe from read only fields from variable edit page

## Related Issue
https://trello.com/c/I20RPEHD/624-it-should-be-possible-to-update-the-universe-of-a-variable-from-the-django-admin-3-hours

## How to test it locally
Go to any existing variable and see if we can add/edit universe.

## Changelog
Removed universe from read only in variable admin

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
