### PR TITLE
Read point data from CSV files as string values

### DIFF
--- a/wazimap_ng/points/tasks.py
+++ b/wazimap_ng/points/tasks.py
@@ -35,6 +35,7 @@ def process_uploaded_file(point_file, subtheme, **kwargs):
         header=None,
         keep_default_na=False,
         encoding=encoding,
+        dtype=str
     ):
         df.columns = old_columns
         df = df.loc[:, new_columns]


### PR DESCRIPTION
## Description

Point location uploads had an issue where phone numbers were dropping the leading 0. This fix should make Pandas read the value as a string instead of an interger

## Related Issue
https://trello.com/c/iGFR5ts9/798-phone-number-in-point-data-dropping-leading-0

## How to test it locally
Please see the Trello card on how to reproduce and test

## Changelog

### Added

### Updated
Fixed leading zero being dropped for phone numbers of point data

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
