### PR TITLE
Adding a WYSIWYG editor for description fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -82,3 +82,4 @@ lorem==0.1.1
 chardet==3.0.4
 
 django-admin-json-editor==0.2.3
+django-tinymce==3.3.0

--- a/wazimap_ng/config/common.py
+++ b/wazimap_ng/config/common.py
@@ -56,6 +56,7 @@ class Common(QCluster, Configuration):
         "django_json_widget",        # admin widget for JSONField
         'whitenoise.runserver_nostatic',
         "django_admin_json_editor",
+        "tinymce",
 
         "debug_toolbar",
         "django_q",

--- a/wazimap_ng/datasets/models/geography.py
+++ b/wazimap_ng/datasets/models/geography.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.postgres.indexes import GinIndex
+from tinymce.models import HTMLField
 
 from treebeard.mp_tree import MP_Node
 from treebeard.mp_tree import MP_NodeManager, MP_NodeQuerySet
@@ -72,7 +73,7 @@ class Geography(MP_Node, BaseModel):
 class GeographyHierarchy(BaseModel):
     name = models.CharField(max_length=50)
     root_geography = models.ForeignKey(Geography, null=False, on_delete=models.CASCADE)
-    description = models.TextField(blank=True)
+    description = HTMLField(blank=True)
 
     @property
     def version(self):

--- a/wazimap_ng/datasets/models/metadata.py
+++ b/wazimap_ng/datasets/models/metadata.py
@@ -1,4 +1,5 @@
 from django.db import models
+from tinymce.models import HTMLField
 
 from .licence import Licence
 from .dataset import Dataset
@@ -7,7 +8,7 @@ from wazimap_ng.general.models import BaseModel
 class MetaData(BaseModel):
     source = models.CharField(max_length=60, null=False, blank=True)
     url = models.URLField(null=True, blank=True)
-    description = models.TextField(blank=True)
+    description = HTMLField(blank=True)
     licence = models.ForeignKey(
         Licence, null=True, blank=True, on_delete=models.SET_NULL,
         related_name="dataset_license"

--- a/wazimap_ng/points/models.py
+++ b/wazimap_ng/points/models.py
@@ -4,6 +4,7 @@ from django.contrib.gis.db import models
 from django.contrib.postgres.fields import JSONField
 from django.core.validators import FileExtensionValidator
 from django.core.exceptions import ValidationError
+from tinymce.models import HTMLField
 
 import pandas as pd
 from io import BytesIO
@@ -70,7 +71,7 @@ class ProfileCategory(BaseModel):
     theme = models.ForeignKey(Theme, on_delete=models.CASCADE, null=True, related_name="profile_categories")
     category = models.ForeignKey(Category, on_delete=models.CASCADE, verbose_name="collection")
     label = models.CharField(max_length=60, null=False, blank=True, help_text="Label for the category to be displayed on the front-end")
-    description = models.TextField(blank=True)
+    description = HTMLField(blank=True)
     icon = models.CharField(max_length=30, null=True, blank=True)
     order = models.PositiveIntegerField(default=0, blank=False, null=False)
     color = ColorField(blank=True)

--- a/wazimap_ng/points/tasks.py
+++ b/wazimap_ng/points/tasks.py
@@ -35,6 +35,7 @@ def process_uploaded_file(point_file, subtheme, **kwargs):
         header=None,
         keep_default_na=False,
         encoding=encoding,
+        dtype=str
     ):
         df.columns = old_columns
         df = df.loc[:, new_columns]

--- a/wazimap_ng/points/tasks.py
+++ b/wazimap_ng/points/tasks.py
@@ -35,7 +35,6 @@ def process_uploaded_file(point_file, subtheme, **kwargs):
         header=None,
         keep_default_na=False,
         encoding=encoding,
-        dtype=str
     ):
         df.columns = old_columns
         df = df.loc[:, new_columns]

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -1,6 +1,7 @@
 from django.contrib.gis.db import models
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
+from tinymce.models import HTMLField
 
 from wazimap_ng.datasets.models import Indicator, GeographyHierarchy
 from wazimap_ng.general.models import BaseModel
@@ -11,7 +12,7 @@ class Profile(BaseModel):
     indicators = models.ManyToManyField(Indicator, through="profile.ProfileIndicator", verbose_name="variables")
     geography_hierarchy = models.ForeignKey(GeographyHierarchy, on_delete=models.PROTECT, null=False)
     permission_type = models.CharField(choices=PERMISSION_TYPES, max_length=32, default="public")
-    description = models.TextField(max_length=255, blank=True)
+    description = HTMLField(max_length=255, blank=True)
     configuration = JSONField(default=dict, blank=True)
 
     def __str__(self):
@@ -40,7 +41,7 @@ class ChoroplethMethod(BaseModel):
 class IndicatorCategory(BaseModel):
     name = models.CharField(max_length=255)
     profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
-    description = models.TextField(blank=True)
+    description = HTMLField(blank=True)
     order = models.PositiveIntegerField(default=0, blank=False, null=False)
     icon = models.CharField(max_length=30, null=True, blank=True)
 
@@ -55,7 +56,7 @@ class IndicatorCategory(BaseModel):
 class IndicatorSubcategory(BaseModel):
     name = models.CharField(max_length=255)
     category = models.ForeignKey(IndicatorCategory, on_delete=models.CASCADE)
-    description = models.TextField(blank=True)
+    description = HTMLField(blank=True)
     order = models.PositiveIntegerField(default=0, blank=False, null=False)
 
     def __str__(self):
@@ -107,7 +108,7 @@ class ProfileIndicator(BaseModel):
     indicator = models.ForeignKey(Indicator, on_delete=models.CASCADE, help_text="Indicator on which this indicator is based on.", verbose_name="variable")
     subcategory = models.ForeignKey(IndicatorSubcategory, on_delete=models.CASCADE)
     label = models.CharField(max_length=255, null=False, blank=True, help_text="Label for the indicator displayed on the front-end")
-    description = models.TextField(blank=True)
+    description = HTMLField(blank=True)
     subindicators = JSONField(default=list, blank=True)
     choropleth_method = models.ForeignKey(ChoroplethMethod, null=False, on_delete=models.CASCADE)
     order = models.PositiveIntegerField(default=0, blank=False, null=False)


### PR DESCRIPTION
## Description
TinyMCE adds an editor to admin pages for HTML based WYSIWYG models. Descriptions are now converted to HTML markdown. List of descriptions changed
- Dataset metadata
- Geography hierarchy
- Profile collections(category)
- Indicator category
- Indicator subcategory
- Profile indicator
- Profile

## Related Issue
https://trello.com/c/E9XN4wrh/803-rich-text-descriptions-as-a-user-i-would-like-to-be-able-to-click-links-in-descriptions-and-read-them-easily-so-that-i-can-more

## How to test it locally
Run the service and open an admin page with a description field e.g. profile indicators. A WYSIWYG editor should appear for the description field

## Changelog

### Added
WYSIWYG descriptions for data admins
### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
