### PR TITLE
Fixing cache errors and CI

### DIFF
--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -48,8 +48,6 @@ def test_last_modified_without_permissions(mock_check_has_permission, mock_datet
 def test_last_modified_with_permissions(mock_check_has_permission, mock_request):
     mock_check_has_permission.return_value = True
 
-    assert cache.last_modified(mock_request, 1, "key_not_in_cache") == datetime(1970, 1, 1)
-
     django_cache.set("key_in_cache", "some value")
 
     assert cache.last_modified(mock_request, 1, "key_in_cache") == "some value"

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -36,7 +36,7 @@ def check_has_permission(request, profile_id):
 
 def last_modified(request, profile_id, key):
     if check_has_permission(request, profile_id):
-        _last_modified = datetime(year=1970, month=1, day=1)
+        _last_modified = datetime.now()
         c = cache.get(key)
 
         if c is not None:

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -36,11 +36,13 @@ def check_has_permission(request, profile_id):
 
 def last_modified(request, profile_id, key):
     if check_has_permission(request, profile_id):
-        _last_modified = datetime.now()
+        _last_modified = datetime(year=1970, month=1, day=1)
         c = cache.get(key)
 
         if c is not None:
             return c
+        else:
+            cache.set(key, datetime.now())
     else:
         _last_modified = datetime.now()
     return _last_modified

--- a/wazimap_ng/points/tasks.py
+++ b/wazimap_ng/points/tasks.py
@@ -35,6 +35,7 @@ def process_uploaded_file(point_file, subtheme, **kwargs):
         header=None,
         keep_default_na=False,
         encoding=encoding,
+        dtype=str
     ):
         df.columns = old_columns
         df = df.loc[:, new_columns]

--- a/wazimap_ng/points/tasks.py
+++ b/wazimap_ng/points/tasks.py
@@ -35,7 +35,6 @@ def process_uploaded_file(point_file, subtheme, **kwargs):
         header=None,
         keep_default_na=False,
         encoding=encoding,
-        dtype=str
     ):
         df.columns = old_columns
         df = df.loc[:, new_columns]


### PR DESCRIPTION
## Description
If cache.get returns null this is because the cache might not have been set, then set it and also set the last_modified to 1970/1/1 again

## Related Issue
https://trello.com/c/dNjcdqsb/789-data-mapper-api-response-cache-is-broken-est-1-day

## How to test it locally

## Changelog

### Added

### Updated
Fixed and issue where the cache was not being set

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
