### PR TITLE
Order profile admin list by profile name

### DIFF
--- a/wazimap_ng/profile/admin/admins/profile_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_admin.py
@@ -1,6 +1,6 @@
 from django.contrib.gis import admin
 from django.contrib.postgres import fields
-
+from django.db.models.functions import Lower
 from django_json_widget.widgets import JSONEditorWidget
 
 from ... import models
@@ -9,14 +9,21 @@ from wazimap_ng.general.admin.admin_base import BaseAdminModel
 from wazimap_ng.general.services.permissions import assign_perms_to_group
 from wazimap_ng.general.admin import filters
 
+
 @admin.register(models.Profile)
 class ProfileAdmin(BaseAdminModel):
 
-    list_display = ('name', 'geography_hierarchy',)
+    list_display = (
+        "name",
+        "geography_hierarchy",
+    )
     list_filter = (filters.GeographyHierarchyFilter,)
     formfield_overrides = {
         fields.JSONField: {"widget": JSONEditorWidget},
     }
+
+    def get_ordering(self, request):
+        return [Lower("name")]
 
     def save_model(self, request, obj, form, change):
         is_new = obj.pk == None and change == False

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -1,7 +1,6 @@
 from django.contrib.gis.db import models
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
-from django.db.models.functions import Lower
 
 from wazimap_ng.datasets.models import Indicator, GeographyHierarchy
 from wazimap_ng.general.models import BaseModel
@@ -19,7 +18,7 @@ class Profile(BaseModel):
         return self.name
 
     class Meta:
-        ordering = [Lower("name")]
+        ordering = ["id"]
 
 class Logo(BaseModel):
     profile = models.OneToOneField(Profile, null=False, on_delete=models.CASCADE)

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -1,6 +1,7 @@
 from django.contrib.gis.db import models
 from django.conf import settings
 from django.contrib.postgres.fields import JSONField, ArrayField
+from django.db.models.functions import Lower
 
 from wazimap_ng.datasets.models import Indicator, GeographyHierarchy
 from wazimap_ng.general.models import BaseModel
@@ -18,7 +19,7 @@ class Profile(BaseModel):
         return self.name
 
     class Meta:
-        ordering = ["name"]
+        ordering = [Lower("name")]
 
 class Logo(BaseModel):
     profile = models.OneToOneField(Profile, null=False, on_delete=models.CASCADE)

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -18,7 +18,7 @@ class Profile(BaseModel):
         return self.name
 
     class Meta:
-        ordering = ["id"]
+        ordering = ["name"]
 
 class Logo(BaseModel):
     profile = models.OneToOneField(Profile, null=False, on_delete=models.CASCADE)


### PR DESCRIPTION
## Description
Order profiles by name so that they are easier to find

## Related Issue
https://trello.com/c/Bscyvwko/813-order-profile-admin-list-by-profile-name-by-default-so-that-i-can-easily-find-the-profile-i-want-to-edit

## How to test it locally
View the profile list page in the admin dashboard and check whether the profiles are ordered

## Changelog

### Added

### Updated
Admin dashboard, profiles are listed in order to make them easier to find and edit

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
