### PR TITLE
Separate api endpoint for fetching themes/category count

### DIFF
--- a/tests/general/test_views.py
+++ b/tests/general/test_views.py
@@ -45,12 +45,12 @@ class TestConsolidatedProfileView(APITestCase):
         pc3, pc4 = self.create_multiple_profile_categories(theme2)
 
         response = self.get(
-            'all-details', profile_id=self.profile.pk,
+            'themes-count', profile_id=self.profile.pk,
             geography_code=self.geography.code, extra={'format': 'json'}
         )
         self.assert_http_200_ok()
 
-        theme_data = response.data["themes"]
+        theme_data = response.data
         assert len(theme_data) == 2
         assert theme_data[0]["name"] == theme1.name
         assert theme_data[1]["name"] == theme2.name
@@ -69,12 +69,12 @@ class TestConsolidatedProfileView(APITestCase):
         self.create_multiple_profile_categories(theme2)
 
         response = self.get(
-            'all-details', profile_id=self.profile.pk,
+            'themes-count', profile_id=self.profile.pk,
             geography_code=self.geography.code, extra={'format': 'json'}
         )
         self.assert_http_200_ok()
 
-        theme_data = response.data["themes"]
+        theme_data = response.data
         assert len(theme_data) == 2
         assert theme_data[0]["name"] == theme2.name
         assert theme_data[1]["name"] == theme1.name
@@ -89,12 +89,12 @@ class TestConsolidatedProfileView(APITestCase):
         pc4 = self.create_pc(theme2, order=0, label=F"pc_{theme2.name}")
 
         response = self.get(
-            'all-details', profile_id=self.profile.pk,
+            'themes-count', profile_id=self.profile.pk,
             geography_code=self.geography.code, extra={'format': 'json'}
         )
         self.assert_http_200_ok()
 
-        theme_data = response.data["themes"]
+        theme_data = response.data
         assert theme_data[0]["subthemes"][0]['label'] == pc2.label
         assert theme_data[0]["subthemes"][1]['label'] == pc1.label
         assert theme_data[1]["subthemes"][0]['label'] == pc4.label
@@ -106,12 +106,12 @@ class TestConsolidatedProfileView(APITestCase):
         pc2 = self.create_pc(theme1, order=0, label=F"pc_{theme1.name}")
 
         response = self.get(
-            'all-details', profile_id=self.profile.pk,
+            'themes-count', profile_id=self.profile.pk,
             geography_code=self.geography.code, extra={'format': 'json'}
         )
         self.assert_http_200_ok()
 
-        theme_data = response.data["themes"]
+        theme_data = response.data
         subthemes = theme_data[0]["subthemes"]
         assert subthemes[0]['label'] == pc2.label
         assert subthemes[1]['label'] == pc1.label
@@ -124,12 +124,12 @@ class TestConsolidatedProfileView(APITestCase):
         pc2.save()
 
         response = self.get(
-            'all-details', profile_id=self.profile.pk,
+            'themes-count', profile_id=self.profile.pk,
             geography_code=self.geography.code, extra={'format': 'json'}
         )
         self.assert_http_200_ok()
 
-        theme_data = response.data["themes"]
+        theme_data = response.data
         subthemes = theme_data[0]["subthemes"]
         assert subthemes[0]['label'] == pc3.label
         assert subthemes[1]['label'] == pc1.label

--- a/wazimap_ng/general/views.py
+++ b/wazimap_ng/general/views.py
@@ -47,7 +47,6 @@ def consolidated_profile_helper(profile_id, geography_code):
         "boundary": boundary_js,
         "children": children_boundary_js,
         "parent_layers": parent_layers,
-        "themes": point_views.boundary_point_count_helper(profile, geography)
     })
 
 @condition(etag_func=etag_profile_updated, last_modified_func=last_modified_profile_updated)
@@ -55,6 +54,15 @@ def consolidated_profile_helper(profile_id, geography_code):
 def consolidated_profile(request, profile_id, geography_code):
     js = consolidated_profile_helper(profile_id, geography_code)
     return Response(js)
+
+
+@condition(etag_func=etag_profile_updated, last_modified_func=last_modified_profile_updated)
+@api_view()
+def boundary_point_count(request, profile_id, geography_code):
+    profile = get_object_or_404(profile_models.Profile, pk=profile_id)
+    version = profile.geography_hierarchy.root_geography.version
+    geography = dataset_models.Geography.objects.get(code=geography_code, version=version)
+    return Response(point_views.boundary_point_count_helper(profile, geography))
 
 @condition(etag_func=etag_profile_updated, last_modified_func=last_modified_profile_updated)
 @api_view()

--- a/wazimap_ng/points/views.py
+++ b/wazimap_ng/points/views.py
@@ -76,7 +76,7 @@ class LocationList(generics.ListAPIView):
 
 def boundary_point_count_helper(profile, geography):
 
-    locations = models.Location.objects.filter(coordinates__contained=geography.geographyboundary.geom)
+    locations = models.Location.objects.filter(coordinates__within=geography.geographyboundary.geom)
     location_count = (
         locations
             .filter(category__profilecategory__profile=profile)

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -154,6 +154,10 @@ urlpatterns = [
         cache(general_views.consolidated_profile_test),
         name="all-details-test"
     ),
+    path("api/v1/profile/<int:profile_id>/geography/<str:geography_code>/themes_count/",
+        cache(general_views.boundary_point_count),
+        name="themes-count"
+    ),
     path("api/v1/tasks/<str:task_id>/", task_status, name="task_status"),
     path('sentry-debug/', trigger_error),
 


### PR DESCRIPTION
## Description
Separated api for Themes from all_details

* Create a separate URL and View in general
* Removed themes from all_details view

New URL:
`api/v1/profile/<int:profile_id>/geography/<str:geography_code>/themes_count/`

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-79

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
