### PR TITLE
Fixed permissions issue for profile admin collection

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -22,6 +22,59 @@ from tests.profile.factories import (
     ProfileKeyMetricsFactory
 )
 from wazimap_ng.datasets.models import Geography, GeographyHierarchy
+from wazimap_ng.profile.models import Profile
+
+from django.test import RequestFactory
+
+from tests.general.factories import (
+    UserFactory, AuthGroupFactory
+)
+
+from guardian.shortcuts import (
+    get_perms_for_model, assign_perm
+)
+
+
+class MockSuperUser:
+    def has_perm(self, perm, obj=None):
+        return True
+
+    @property
+    def is_superuser(self):
+        return True
+
+
+@pytest.fixture
+def profile_admin_group():
+    return AuthGroupFactory(name="ProfileAdmin")
+
+@pytest.fixture
+def profile_admin_user(profile_admin_group):
+    user = UserFactory(is_staff=True)
+    user.groups.add(profile_admin_group)
+    return user
+
+@pytest.fixture
+def superuser():
+    return MockSuperUser()
+
+@pytest.fixture
+def factory():
+    return RequestFactory()
+
+@pytest.fixture
+def mocked_request(factory, superuser):
+    request = factory.get('/get/request')
+    request.method = 'GET'
+    request.user = superuser
+    return request
+
+@pytest.fixture
+def mocked_request_profileadmin(factory, profile_admin_user):
+    request = factory.get('/get/request')
+    request.method = 'GET'
+    request.user = profile_admin_user
+    return request
 
 
 @pytest.fixture
@@ -71,6 +124,29 @@ def profile(geography_hierarchy):
     }
 
     return ProfileFactory(geography_hierarchy=geography_hierarchy, configuration=configuration)
+
+@pytest.fixture
+def profile_group(profile):
+    profile_group = AuthGroupFactory(name=profile.name)
+    for perm in get_perms_for_model(Profile):
+        assign_perm(perm, profile_group, profile)
+
+    return profile_group
+
+@pytest.fixture
+def private_profile(geography_hierarchy):
+    return ProfileFactory(
+        name="private profile", permission_type="private",
+        geography_hierarchy=geography_hierarchy
+    )
+
+@pytest.fixture
+def private_profile_group(private_profile):
+    profile_group = AuthGroupFactory(name=private_profile.name)
+    for perm in get_perms_for_model(Profile):
+        assign_perm(perm, profile_group, private_profile)
+
+    return profile_group
 
 
 @pytest.fixture
@@ -201,14 +277,16 @@ def profile_indicator(profile, indicatordata):
 @pytest.fixture
 def category(profile_indicator):
     c = profile_indicator.subcategory.category
+    c.profile_id = profile_indicator.profile_id
     c.name = "A test category"
     c.save()
     return c
 
 
 @pytest.fixture
-def subcategory(profile_indicator):
+def subcategory(profile_indicator, category):
     s = profile_indicator.subcategory
+    s.category = category
     s.name = "A test subcategory"
     s.save()
     return s
@@ -226,3 +304,69 @@ def profile_highlight(profile, indicatordata):
     FEMALE_GROUP_INDEX = 1
     indicator = indicatordata[0].indicator
     return ProfileHighlightFactory(profile=profile, indicator=indicator, subindicator=FEMALE_GROUP_INDEX)
+
+
+# Qualitative content indicator
+
+@pytest.fixture
+def qualitative_dataset(profile):
+    return DatasetFactory(profile=profile, content_type="qualitative")
+
+@pytest.fixture
+def qualitative_groups(qualitative_dataset):
+    return [
+        GroupFactory(
+            dataset=qualitative_dataset,
+            name="content",
+            subindicators=["This is example text", "www.test.com"],
+            can_aggregate=True, can_filter=True),
+    ]
+
+@pytest.fixture
+def qualitative_indicator(qualitative_dataset):
+    subindicators = ["This is example text", "www.test.com"]
+    groups = ["content"]
+    return IndicatorFactory(dataset=qualitative_dataset, subindicators=subindicators, groups=groups)
+
+@pytest.fixture
+def qualitative_indicatordata(qualitative_indicator, geography):
+    return [
+        IndicatorDataFactory(
+            indicator=qualitative_indicator,
+            geography=geography,
+            data=[
+                  {
+                    "content": "This is example text"
+                  },
+                  {
+                    "content": "www.test.com"
+                  }
+            ]
+        )
+    ]
+
+@pytest.fixture
+def qualitative_profile_indicator(profile, qualitative_indicatordata):
+    indicator = qualitative_indicatordata[0].indicator
+    return ProfileIndicatorFactory(
+        profile=profile, indicator=indicator,
+        label="qualitative content"
+    )
+
+
+@pytest.fixture
+def qualitative_category(qualitative_profile_indicator):
+    c = qualitative_profile_indicator.subcategory.category
+    c.profile_id = qualitative_profile_indicator.profile_id
+    c.name = "A test category"
+    c.save()
+    return c
+
+
+@pytest.fixture
+def qualitative_subcategory(qualitative_profile_indicator, category):
+    s = qualitative_profile_indicator.subcategory
+    s.category = category
+    s.name = "A test subcategory"
+    s.save()
+    return s

--- a/tests/general/factories.py
+++ b/tests/general/factories.py
@@ -6,6 +6,10 @@ from django_q.models import Task
 
 from tests.datasets.factories import LicenceFactory
 
+import django.contrib.auth.models as auth_models
+from django.contrib.auth.hashers import make_password
+
+
 class MetaDataFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = MetaData
@@ -20,3 +24,22 @@ class TaskFactory(factory.django.DjangoModelFactory):
     stopped = datetime.now()
     success = True
     name = factory.Sequence(lambda n: 'task%d' % n)
+
+
+class AuthGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.Group
+        django_get_or_create = ('name',)
+
+    name = factory.Faker('name')
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.User
+
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    username = factory.Faker('email')
+    password = factory.LazyFunction(lambda: make_password('pi3.1415'))
+    is_active = True

--- a/tests/points/admin/test_profile_category_admin.py
+++ b/tests/points/admin/test_profile_category_admin.py
@@ -1,0 +1,31 @@
+import pytest
+
+from django.contrib.admin.sites import AdminSite
+
+from wazimap_ng.points.models import ProfileCategory
+from wazimap_ng.points.admin import ProfileCategoryAdmin
+
+
+@pytest.mark.django_db
+class TestProfileCategoryAdmin:
+
+    def test_modeladmin_str(self):
+        admin_site = ProfileCategoryAdmin(ProfileCategory, AdminSite())
+        assert str(admin_site) == 'points.ProfileCategoryAdmin'
+
+    def test_can_profile_admin_view_collection_without_perms(
+            self, mocked_request_profileadmin, profile_category
+        ):
+        collection_admin = ProfileCategoryAdmin(ProfileCategory, AdminSite())
+        queryset = collection_admin.get_queryset(mocked_request_profileadmin)
+        assert queryset.count() == 0
+
+    def test_can_profile_admin_view_collection_with_perms(
+            self, mocked_request_profileadmin, profile_category, profile_group,
+            profile_admin_user
+        ):
+        profile_admin_user.groups.add(profile_group)
+        collection_admin = ProfileCategoryAdmin(ProfileCategory, AdminSite())
+        queryset = collection_admin.get_queryset(mocked_request_profileadmin)
+        assert queryset.count() == 1
+        assert queryset.first() == profile_category

--- a/tests/points/conftest.py
+++ b/tests/points/conftest.py
@@ -5,12 +5,8 @@ from tests.profile.factories import ProfileFactory
 
 
 @pytest.fixture
-def profile():
-    return ProfileFactory()
-
-@pytest.fixture
-def theme():
-    return ThemeFactory()
+def theme(profile):
+    return ThemeFactory(profile=profile)
 
 @pytest.fixture
 def profile_category(theme):

--- a/wazimap_ng/general/admin/filters.py
+++ b/wazimap_ng/general/admin/filters.py
@@ -63,7 +63,7 @@ class ThemeFilter(DynamicBaseFilter):
 
     def lookups(self, request, model_admin):
         profiles = permissions.get_objects_for_user(
-            request.user, Profile, include_public=True
+            request.user, Profile, include_public=False
         )
         return [(theme.id, theme) for theme in self.model_class.objects.filter(
             profile__in=profiles

--- a/wazimap_ng/general/services/custom_permissions/queryset_filters.py
+++ b/wazimap_ng/general/services/custom_permissions/queryset_filters.py
@@ -71,7 +71,9 @@ class CustomQuerySet(models.QuerySet):
 
 	# Points
 	def get_points_category_queryset(self, user):
-		profiles = permissions.get_objects_for_user(user, Profile)
+		profiles = permissions.get_objects_for_user(
+			user, Profile, include_public=False
+		)
 
 		return permissions.get_objects_for_user(
 			user, Category, queryset=self.filter(profile__in=profiles)
@@ -95,7 +97,7 @@ class CustomQuerySet(models.QuerySet):
 	def get_points_profilecategory_queryset(self, user):
 
 		profiles = permissions.get_objects_for_user(
-		    user, Profile
+		    user, Profile, include_public=False
 		)
 		return permissions.get_objects_for_user(
 		    user, ProfileCategory

--- a/wazimap_ng/general/services/permissions.py
+++ b/wazimap_ng/general/services/permissions.py
@@ -71,7 +71,7 @@ def get_objects_for_user(
         queryset = model.objects.all()
 
     if not hasattr(model, 'permission_type'):
-        return model.objects.none()
+        return queryset
 
     model_name, app_label = get_model_info(model)
     codename = get_permission_codename(perm, model._meta)


### PR DESCRIPTION
## Description
* Fixed bug in returning queryset for models that does not contain permission field
* Fixed issue with profile collection filters

## Related Issue
https://trello.com/c/QOFwczgp/518-point-collection-permissions-needed-for-profile-accounts

## How to test it locally
Create a user with staff perms and assign group ProfileAdmin and any profile group from admin panel.
Login in admin and check if you can CRUD Profile Collection and Themes

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
