### PR TITLE
Read point data from CSV files as string values

### DIFF
--- a/tests/points/test_tasks.py
+++ b/tests/points/test_tasks.py
@@ -45,7 +45,12 @@ data_with_different_encodings = [
     (150.12345, 30.12345, "€ŠPointFile1®®"),
 ]
 
+data_with_additional_variables = [
+    (123.45678, 36.84302, "PointFile1", "0123456789"),
+]
+
 good_header = ["longitude", "latitude", "name"]
+header_with_additional_variables = ["longitude", "latitude", "name", "phone number"]
 
 to_be_fixed_header = [" longitude ", " latitude", "name "]
 
@@ -56,6 +61,7 @@ to_be_fixed_header = [" longitude ", " latitude", "name "]
         (good_data, to_be_fixed_header, "utf8"),
         (data_with_different_case, good_header, "utf8"),
         (data_with_different_encodings, good_header, "Windows-1252"),
+        (data_with_additional_variables, header_with_additional_variables, "utf8"),
     ]
 )
 def data(request):
@@ -79,3 +85,7 @@ class TestUploadFile:
         for dd, ed in zip(location_data, csv_data):
             assert pytest.approx(dd.coordinates.x) == ed[0]
             assert pytest.approx(dd.coordinates.y) == ed[1]
+
+            if len(dd.data) > 0:
+                if dd.data[0]["key"] == "phone number":
+                    assert ed[3] == dd.data[0]["value"]

--- a/tests/points/test_tasks.py
+++ b/tests/points/test_tasks.py
@@ -83,6 +83,8 @@ class TestUploadFile:
         assert len(location_data) == len(csv_data)
 
         for dd, ed in zip(location_data, csv_data):
+            assert type(dd.coordinates.y) == float
+            assert type(dd.coordinates.y) == float
             assert pytest.approx(dd.coordinates.x) == ed[0]
             assert pytest.approx(dd.coordinates.y) == ed[1]
 

--- a/wazimap_ng/points/tasks.py
+++ b/wazimap_ng/points/tasks.py
@@ -35,6 +35,7 @@ def process_uploaded_file(point_file, subtheme, **kwargs):
         header=None,
         keep_default_na=False,
         encoding=encoding,
+        dtype=str
     ):
         df.columns = old_columns
         df = df.loc[:, new_columns]


### PR DESCRIPTION
## Description
This is the second PR to fix point location uploads that had an issue where phone numbers were dropping the leading 0. This fix should make Pandas read the value as a string instead of an interger

## Related Issue
https://trello.com/c/iGFR5ts9/798-phone-number-in-point-data-dropping-leading-0

## How to test it locally
Please see the Trello card on how to reproduce and test

## Changelog

### Added

### Updated
Fixed leading zero being dropped for phone numbers of point data

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
