### PR TITLE
Fixed bug in deleting dataset from admin panel and themes auto load in profile collection admin view

### DIFF
--- a/tests/general/factories.py
+++ b/tests/general/factories.py
@@ -6,6 +6,10 @@ from django_q.models import Task
 
 from tests.datasets.factories import LicenceFactory
 
+import django.contrib.auth.models as auth_models
+from django.contrib.auth.hashers import make_password
+
+
 class MetaDataFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = MetaData
@@ -20,3 +24,22 @@ class TaskFactory(factory.django.DjangoModelFactory):
     stopped = datetime.now()
     success = True
     name = factory.Sequence(lambda n: 'task%d' % n)
+
+
+class AuthGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.Group
+        django_get_or_create = ('name',)
+
+    name = factory.Faker('name')
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.User
+
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    username = factory.Faker('email')
+    password = factory.LazyFunction(lambda: make_password('pi3.1415'))
+    is_active = True

--- a/tests/points/conftest.py
+++ b/tests/points/conftest.py
@@ -13,5 +13,10 @@ def theme():
     return ThemeFactory()
 
 @pytest.fixture
+def private_profile_theme(private_profile):
+    return ThemeFactory(profile=private_profile)
+
+@pytest.fixture
 def profile_category(theme):
     return ProfileCategoryFactory(theme=theme, label="profile category name", description="my test profile category", color="red", profile=theme.profile)
+

--- a/tests/points/test_views.py
+++ b/tests/points/test_views.py
@@ -2,6 +2,7 @@ from test_plus import APITestCase
 import pytest
 
 from django.contrib.gis.geos import Point, Polygon, MultiPolygon
+from django.urls import reverse
 
 from wazimap_ng.points.models import Theme
 from wazimap_ng.points.serializers import ThemeSerializer
@@ -53,6 +54,20 @@ class TestThemeView:
         expected = ThemeSerializer(instance=themes, many=True).data
         actual = tp_api.last_response.json()
 
+        assert actual == expected
+
+
+    def test_points_themes_list_for_private_profile(
+            self, client, private_profile, private_profile_theme, profile_admin_user, private_profile_group
+        ):
+        profile_admin_user.groups.add(private_profile_group)
+        client.force_login(user=profile_admin_user)
+        res = client.get(reverse("points-themes", args=(private_profile.id,)))
+        assert res.status_code == 200
+        actual = res.json()
+
+        themes = Theme.objects.filter(profile=private_profile)
+        expected = ThemeSerializer(instance=themes, many=True).data
         assert actual == expected
 
 class TestLocationView(APITestCase):

--- a/wazimap_ng/cache.py
+++ b/wazimap_ng/cache.py
@@ -3,7 +3,7 @@ from datetime import datetime
 
 from django.core.cache import cache
 from django.db.models import Q
-from django.db.models.signals import post_save, post_delete
+from django.db.models.signals import post_save, pre_delete
 from django.dispatch import receiver
 from django.http import Http404
 from django.views.decorators.cache import cache_control
@@ -91,43 +91,43 @@ def update_point_cache(profile, category):
     cache.set(key1, datetime.now())
 
 
-@receiver(post_delete, sender=ProfileIndicator)
+@receiver(pre_delete, sender=ProfileIndicator)
 @receiver(post_save, sender=ProfileIndicator)
 def profile_indicator_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
-@receiver(post_delete, sender=ProfileHighlight)
+@receiver(pre_delete, sender=ProfileHighlight)
 @receiver(post_save, sender=ProfileHighlight)
 def profile_highlight_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
-@receiver(post_delete, sender=IndicatorCategory)
+@receiver(pre_delete, sender=IndicatorCategory)
 @receiver(post_save, sender=IndicatorCategory)
 def profile_category_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
-@receiver(post_delete, sender=IndicatorSubcategory)
+@receiver(pre_delete, sender=IndicatorSubcategory)
 @receiver(post_save, sender=IndicatorSubcategory)
 def profile_subcategory_updated(sender, instance, **kwargs):
     update_profile_cache(instance.category.profile)
 
 
-@receiver(post_delete, sender=ProfileKeyMetrics)
+@receiver(pre_delete, sender=ProfileKeyMetrics)
 @receiver(post_save, sender=ProfileKeyMetrics)
 def profile_keymetrics_updated(sender, instance, **kwargs):
     update_profile_cache(instance.profile)
 
 
-@receiver(post_delete, sender=Profile)
+@receiver(pre_delete, sender=Profile)
 @receiver(post_save, sender=Profile)
 def profile_updated(sender, instance, **kwargs):
     update_profile_cache(instance)
 
 
-@receiver(post_delete, sender=Group)
+@receiver(pre_delete, sender=Group)
 @receiver(post_save, sender=Group)
 def subindicator_group_update(sender, instance, **kwargs):
     indicator_ids = instance.dataset.indicator_set.values_list("id", flat=True)
@@ -141,7 +141,7 @@ def subindicator_group_update(sender, instance, **kwargs):
         update_profile_cache(profile_obj)
 
 
-@receiver(post_delete, sender=Location)
+@receiver(pre_delete, sender=Location)
 @receiver(post_save, sender=Location)
 def point_updated_location(sender, instance, **kwargs):
     for pc in instance.category.profilecategory_set.all():
@@ -149,7 +149,7 @@ def point_updated_location(sender, instance, **kwargs):
         update_profile_cache(pc.profile)
 
 
-@receiver(post_delete, sender=Category)
+@receiver(pre_delete, sender=Category)
 @receiver(post_save, sender=Category)
 def point_updated_category(sender, instance, **kwargs):
     profile_categoies = instance.profilecategory_set.all()
@@ -158,14 +158,14 @@ def point_updated_category(sender, instance, **kwargs):
         update_profile_cache(pc.profile)
 
 
-@receiver(post_delete, sender=ProfileCategory)
+@receiver(pre_delete, sender=ProfileCategory)
 @receiver(post_save, sender=ProfileCategory)
 def point_updated_profile_category(sender, instance, **kwargs):
     update_point_cache(instance.profile, instance)
     update_profile_cache(instance.profile)
 
 
-@receiver(post_delete, sender=Indicator)
+@receiver(pre_delete, sender=Indicator)
 @receiver(post_save, sender=Indicator)
 def indicator_updated(sender, instance, **kwargs):
     indicator_id = instance.id
@@ -178,7 +178,7 @@ def indicator_updated(sender, instance, **kwargs):
         update_profile_cache(profile_obj)
 
 
-@receiver(post_delete, sender=Geography)
+@receiver(pre_delete, sender=Geography)
 @receiver(post_save, sender=Geography)
 def geography_updated(sender, instance, **kwargs):
 
@@ -202,7 +202,7 @@ def geography_updated(sender, instance, **kwargs):
         update_profile_cache(profile)
 
 
-@receiver(post_delete, sender=GeographyHierarchy)
+@receiver(pre_delete, sender=GeographyHierarchy)
 @receiver(post_save, sender=GeographyHierarchy)
 def geography_hierarchy_updated(sender, instance, **kwargs):
     for profile in instance.profile_set.all():

--- a/wazimap_ng/config/common.py
+++ b/wazimap_ng/config/common.py
@@ -283,6 +283,7 @@ class Common(QCluster, Configuration):
         ),
         'DEFAULT_AUTHENTICATION_CLASSES': [
             "rest_framework.authentication.TokenAuthentication",
+            "rest_framework.authentication.SessionAuthentication",
         ],
         'DEFAULT_PERMISSION_CLASSES': [
             "wazimap_ng.profile.authentication.ProfilePermissions",


### PR DESCRIPTION
## Description
* Used Pre delete signal so instance exists when cache is deleted
    We were using post delete and at the point when were removing cache data was already deleted from DB.
    So now i have changed signal from post_delete to pre_delete.
    Cache will be removed at the start of deletion process
    
* Added session authentication so admin user is able access api from admin panel
   admin user was not able fetch api for private profiles as the user was always regarded as Anonymous user.
   Added session authentication in DRF so it will recognise user that is logged in as session and profile authentication will work on permissions.

## Related Issue
https://trello.com/c/WDlD3TkR/867-unable-to-delete-dataset
https://openupsa.slack.com/archives/C01PV6DJY2C/p1627630209002200

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
