### PR TITLE
Fix notifications for dataset data delete

### DIFF
--- a/wazimap_ng/general/templates/admin/base.html
+++ b/wazimap_ng/general/templates/admin/base.html
@@ -6,27 +6,24 @@
 	<script src="/static/admin/js/vendor/jquery/jquery.js"></script>
 	<script type="text/javascript" src="/static/js/toastr.min.js"></script>
     <script type="text/javascript">
-
-    	var notifications = {{ request.session |get_notifications|safe }};
-    	if(notifications){
-    		notify(notifications);
-    	}
-
-    	var task_in_progress = {{ request.session |get_task_list|safe }};
+    	show_notifications();
     	setInterval(function(){
-    		if (task_in_progress.length){
-    			$.ajax({
-	                url: "{% url 'notifications' %}",
-	                success: function(data) {
-	                    let notifications = data.notifications;
-	                    if(notifications.length){
-	                    	notify(notifications);
-	                    }
-	                    task_in_progress = data.task_list;
-	                }
-	            })
-			}
+			show_notifications();
 		}, 10000)
+
+
+		function show_notifications(){
+			$.ajax({
+                url: "{% url 'notifications' %}",
+                success: function(data) {
+                    let notifications = data.notifications;
+                    if(notifications.length){
+                    	notify(notifications);
+                    }
+                    task_in_progress = data.task_list;
+                }
+            })
+		}
 			
 
 	    function notify(notifications){


### PR DESCRIPTION
## Description
Show notification after deleting datasets.
Do not show Django success notification.
Create custom notification for deleted data.

## Related Issue
https://trello.com/c/nh1PM1ro/869-dataadmin-is-able-to-delete-dataset-without-perms-from-list-view-of-admin-panel

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
