### PR TITLE
Check for dataset profile perms before deleting datasets from admin list view

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,5 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: docker-compose run --rm web python wait_for_postgres.py
+      - run: docker-compose run --rm web python manage.py collectstatic --no-input
       - name: Run tests
         run: docker-compose run --rm -e DJANGO_CONFIGURATION=Test web pytest /app/tests

--- a/tests/datasets/admin/test_dataset_admin.py
+++ b/tests/datasets/admin/test_dataset_admin.py
@@ -1,0 +1,154 @@
+import pytest
+
+from unittest.mock import patch
+from django.urls import reverse
+
+from django.contrib.admin.sites import AdminSite
+
+from wazimap_ng.datasets.models import Dataset
+from wazimap_ng.datasets.admin import DatasetAdmin
+
+
+@pytest.mark.django_db
+class TestDatasetAdmin:
+
+    def test_modeladmin_str(self):
+        admin_site = DatasetAdmin(Dataset, AdminSite())
+        assert str(admin_site) == 'datasets.DatasetAdmin'
+
+    def test_can_data_admin_view_private_dataset_without_perms(
+            self, mocked_request_dataadmin, dataset
+        ):
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        queryset = dataset_admin.get_queryset(mocked_request_dataadmin)
+        assert queryset.count() == 0
+        assert dataset.permission_type == "private"
+
+    def test_can_data_admin_view_private_dataset_with_perms(
+            self, mocked_request_dataadmin, dataset, data_admin_user, profile_group
+        ):
+
+        # Assign profile group to user
+        data_admin_user.groups.add(profile_group)
+        assert profile_group.name == dataset.profile.name
+        assert dataset.permission_type == "private"
+
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        queryset = dataset_admin.get_queryset(mocked_request_dataadmin)
+        assert queryset.count() == 1
+        assert queryset.first() == dataset
+
+    def test_can_data_admin_view_public_dataset_without_perms(
+            self, mocked_request_dataadmin, public_dataset
+        ):
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        queryset = dataset_admin.get_queryset(mocked_request_dataadmin)
+        assert public_dataset.permission_type == "public"
+        assert queryset.count() == 1
+        assert queryset.first() == public_dataset
+
+    def test_can_admin_delete_dataset_object_without_perms(
+            self, mocked_request_dataadmin, public_dataset
+        ):
+
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        has_perm = dataset_admin.has_delete_permission(
+            mocked_request_dataadmin, public_dataset
+        )
+        assert has_perm == False
+
+    @patch("django.contrib.admin.ModelAdmin.has_delete_permission")
+    def test_can_admin_delete_public_dataset_object_with_perms(
+            self, mock_delete_perm, mocked_request_dataadmin, public_dataset, data_admin_user,
+            profile_group
+        ):
+        mock_delete_perm.return_value = True
+
+        # Assign profile group to user
+        data_admin_user.groups.add(profile_group)
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        has_perm = dataset_admin.has_delete_permission(
+            mocked_request_dataadmin, public_dataset
+        )
+        assert has_perm == True
+
+
+    @patch("django.contrib.admin.ModelAdmin.has_delete_permission")
+    @patch("django.contrib.admin.ModelAdmin.has_view_permission")
+    def test_can_user_delete_datasets_using_action_without_perm(
+            self, mock_delete_perm, mock_view_perm, client, mocked_request_dataadmin, public_dataset,
+            dataset, data_admin_user
+        ):
+
+        mock_delete_perm.return_value = True
+        mock_view_perm.return_value = True
+        client.force_login(user=data_admin_user)
+
+        data = {
+            'action': 'delete_selected_data',
+            '_selected_action': [public_dataset.id,],
+            'post': 'yes',
+        }
+        change_url = reverse('admin:datasets_dataset_changelist')
+        
+        response = client.post(change_url, data, follow=True)
+        assert response.status_code == 200
+
+        messages = list(response.context['messages'])
+        assert len(messages) == 1
+        assert messages[0].level == 40
+        message = messages[0].message.replace(" ", "")
+        assert  message== """
+            Can not proceed with deletion as you do not have permission to delete all selected datasets.
+              Please review your selection and try again
+        """.replace(" ", "")
+
+        # Check if public dataset is not deleted
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        queryset = dataset_admin.get_queryset(mocked_request_dataadmin)
+        assert public_dataset.permission_type == "public"
+        assert queryset.count() == 1
+        assert queryset.first() == public_dataset
+
+
+    @patch("django.contrib.admin.ModelAdmin.has_delete_permission")
+    @patch("django.contrib.admin.ModelAdmin.has_view_permission")
+    def test_can_user_delete_datasets_using_action_with_perm(
+            self, mock_delete_perm, mock_view_perm, client, mocked_request_dataadmin, public_dataset,
+            dataset, data_admin_user, profile_group
+        ):
+
+        mock_delete_perm.return_value = True
+        mock_view_perm.return_value = True
+        client.force_login(user=data_admin_user)
+        data_admin_user.groups.add(profile_group)
+
+        # Check existing datasets
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        queryset = dataset_admin.get_queryset(mocked_request_dataadmin)
+        assert queryset.count() == 2
+        assert public_dataset in queryset
+        assert dataset in queryset
+
+        data = {
+            'action': 'delete_selected_data',
+            '_selected_action': [public_dataset.id,],
+            'post': 'yes',
+        }
+
+        change_url = reverse('admin:datasets_dataset_changelist')
+        response = client.post(change_url, data, follow=True)
+        assert response.status_code == 200
+        messages = list(response.context['messages'])
+        assert len(messages) == 0
+
+        notifications = response.context["request"].session["notifications"]
+        assert len(notifications) == 1
+        assert notifications[0]["type"] == "success"
+        assert notifications[0]["message"] == "Data deleted for dataset - public dataset"
+
+        # Check if public dataset is not deleted
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        queryset = dataset_admin.get_queryset(mocked_request_dataadmin)
+        assert queryset.count() == 1
+        assert queryset.first() == dataset

--- a/tests/general/factories.py
+++ b/tests/general/factories.py
@@ -6,6 +6,10 @@ from django_q.models import Task
 
 from tests.datasets.factories import LicenceFactory
 
+import django.contrib.auth.models as auth_models
+from django.contrib.auth.hashers import make_password
+
+
 class MetaDataFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = MetaData
@@ -20,3 +24,22 @@ class TaskFactory(factory.django.DjangoModelFactory):
     stopped = datetime.now()
     success = True
     name = factory.Sequence(lambda n: 'task%d' % n)
+
+
+class AuthGroupFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.Group
+        django_get_or_create = ('name',)
+
+    name = factory.Faker('name')
+
+
+class UserFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = auth_models.User
+
+    first_name = factory.Faker('first_name')
+    last_name = factory.Faker('last_name')
+    username = factory.Faker('email')
+    password = factory.LazyFunction(lambda: make_password('pi3.1415'))
+    is_active = True

--- a/tests/general/test_views.py
+++ b/tests/general/test_views.py
@@ -17,7 +17,7 @@ from tests.general.factories import TaskFactory
 class TestConsolidatedProfileView(APITestCase):
 
     def setUp(self):
-        self.geography = GeographyFactory()
+        self.geography = GeographyFactory(depth=0, path='path_0')
         GeographyBoundaryFactory(geography=self.geography)
         self.hierarchy = GeographyHierarchyFactory(root_geography=self.geography)
         self.profile = ProfileFactory(geography_hierarchy=self.hierarchy)

--- a/wazimap_ng/datasets/hooks.py
+++ b/wazimap_ng/datasets/hooks.py
@@ -20,7 +20,7 @@ class Notify:
 
     generic_messages = {
         "delete" : {
-            "success": "Data deleted for %s",
+            "success": "Data deleted for %s - %s",
             "error": "Error in deleting data for %s",
         },
         "upload" : {
@@ -79,8 +79,15 @@ class Notify:
         """
         Get Generic message according to notification type.
         """
+        name = results["data"]
+        if isinstance(name, list) and len(name):
+            if len(name) > 1:
+                name = f"{name[0]} and {len(name) - 1} others."
+            else:
+                name = name[0]
+
         message = self.generic_messages[task_type][notification_type]
-        return message % obj
+        return message % (results["object_name"], name)
 
 def process_task_info(task):
     """

--- a/wazimap_ng/datasets/tasks/delete_data.py
+++ b/wazimap_ng/datasets/tasks/delete_data.py
@@ -12,12 +12,13 @@ def delete_data(data, object_name, **kwargs):
     """
     Delete data
     """
+    str_of_objs = [str(x) for x in data]
     data.delete()
 
     is_queryset = isinstance(data, QuerySet)
 
     return {
         "is_queryset": is_queryset,
-        "data": data,
+        "data": str_of_objs,
         "object_name": object_name,
     }


### PR DESCRIPTION
## Description
Check for dataset permissions before deleting data from list view of dataset admin

## Related Issue
https://trello.com/c/nh1PM1ro/869-dataadmin-is-able-to-delete-dataset-without-perms-from-list-view-of-admin-panel

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
