### PR TITLE
WNCM-191 Api for separating child indicator data from all_details

### DIFF
--- a/tests/general/test_all_details2.py
+++ b/tests/general/test_all_details2.py
@@ -1,0 +1,77 @@
+from test_plus import APITestCase
+
+from tests.profile.factories import ProfileFactory
+from tests.points.factories import (
+    ProfileCategoryFactory, CategoryFactory, LocationFactory
+)
+from tests.datasets.factories import GeographyFactory, GeographyHierarchyFactory, VersionFactory
+from tests.boundaries.factories import GeographyBoundaryFactory
+
+
+class TestConsolidatedProfileViewWithoutChildren(APITestCase):
+
+    def setUp(self):
+        self.version = VersionFactory()
+        self.geography = GeographyFactory()
+        GeographyBoundaryFactory(geography=self.geography, version=self.version)
+        self.hierarchy = GeographyHierarchyFactory(
+            root_geography=self.geography,
+            configuration = {
+                "default_version": self.version.name,
+            }
+        )
+        self.profile = ProfileFactory(geography_hierarchy=self.hierarchy)
+        self.category = CategoryFactory(profile=self.profile)
+        self.location = LocationFactory(category=self.category)
+
+    def create_pc(self, theme, order=0, label="pc label"):
+        return ProfileCategoryFactory(
+            profile=self.profile, category=self.category, theme=theme,
+            label=label, order=order
+        )
+
+    def create_multiple_profile_categories(self, theme, count=2):
+        pcs = []
+        for i in range(0, count):
+            pcs.append(
+                self.create_pc(theme, i, F"pc{i}_{theme.name}")
+            )
+        return pcs
+
+    def test_basic_all_details_default_version(self):
+        response = self.get(
+            'all-details2',
+            profile_id=self.profile.pk,
+            geography_code=self.geography.code,
+            data={
+                'format': 'json',
+            },
+        )
+        self.assert_http_200_ok()
+
+    def test_all_details_one_version(self):
+        response = self.get(
+            'all-details2',
+            profile_id=self.profile.pk,
+            geography_code=self.geography.code,
+            data={
+                'format': 'json',
+                'version': self.version.name
+            },
+        )
+        self.assert_http_200_ok()
+
+    def test_all_details_version_exists_but_not_this_geo(self):
+        other_version = VersionFactory()
+        other_geography = GeographyFactory()
+        other_boundary = GeographyBoundaryFactory(version=other_version, geography=other_geography)
+        response = self.get(
+            'all-details2',
+            profile_id=self.profile.pk,
+            geography_code=self.geography.code,
+            data={
+                'format': 'json',
+                'version': other_version.name
+            },
+        )
+        self.assert_http_404_not_found()

--- a/tests/general/test_all_details_without_children_indicator.py
+++ b/tests/general/test_all_details_without_children_indicator.py
@@ -40,10 +40,11 @@ class TestConsolidatedProfileViewWithoutChildren(APITestCase):
 
     def test_basic_all_details_default_version(self):
         response = self.get(
-            'all-details2',
+            'all-details',
             profile_id=self.profile.pk,
             geography_code=self.geography.code,
             data={
+                'skip-children': True,
                 'format': 'json',
             },
         )
@@ -51,10 +52,11 @@ class TestConsolidatedProfileViewWithoutChildren(APITestCase):
 
     def test_all_details_one_version(self):
         response = self.get(
-            'all-details2',
+            'all-details',
             profile_id=self.profile.pk,
             geography_code=self.geography.code,
             data={
+                'skip-children': True,
                 'format': 'json',
                 'version': self.version.name
             },
@@ -66,10 +68,11 @@ class TestConsolidatedProfileViewWithoutChildren(APITestCase):
         other_geography = GeographyFactory()
         other_boundary = GeographyBoundaryFactory(version=other_version, geography=other_geography)
         response = self.get(
-            'all-details2',
+            'all-details',
             profile_id=self.profile.pk,
             geography_code=self.geography.code,
             data={
+                'skip-children': True,
                 'format': 'json',
                 'version': other_version.name
             },

--- a/tests/profile/serializers/test_indicator_data_for_children.py
+++ b/tests/profile/serializers/test_indicator_data_for_children.py
@@ -162,7 +162,6 @@ class TestIndicatorSerializerForChildren:
         category = pi.subcategory.category
         subcategory = pi.subcategory
         data = IndicatorDataSerializerForChildren(profile, root_geo, version2)
-        print(dict(data))
         pi_data = data[category.name]["subcategories"][subcategory.name]["indicators"][pi.label]["data"]
         assert "WC" in pi_data
         assert "EC" in pi_data

--- a/tests/profile/serializers/test_indicator_data_for_children.py
+++ b/tests/profile/serializers/test_indicator_data_for_children.py
@@ -131,6 +131,9 @@ def indicator_data_geo2(geo2, profile_indicators, indicatordata_json):
     return idata
 
 @pytest.mark.django_db
+
+@pytest.mark.usefixtures("create_boundaries")
+@pytest.mark.usefixtures("indicator_data")
 class TestIndicatorSerializerForChildren:
     def test_children_indicator_data_for_version1(
         self, profile, root_geo, version1, profile_indicators, create_boundaries,
@@ -143,15 +146,16 @@ class TestIndicatorSerializerForChildren:
         """
         pi = profile_indicators[0]
         category = pi.subcategory.category
-        subcategory =pi.subcategory
+        subcategory = pi.subcategory
         data = IndicatorDataSerializerForChildren(profile, root_geo, version1)
         pi_data = data[category.name]["subcategories"][subcategory.name]["indicators"][pi.label]["data"]
         assert "WC" in pi_data
         assert pi_data["WC"] == pi.indicator.indicatordata_set.get(geography__code="WC").data
 
+    @pytest.mark.usefixtures("create_boundaries")
+    @pytest.mark.usefixtures("indicator_data")
     def test_children_indicator_data_for_version2(
-        self, profile, root_geo, version2, profile_indicators, create_boundaries,
-        indicator_data
+        self, profile, root_geo, version2, profile_indicators
     ):
         """
         For version2
@@ -163,6 +167,7 @@ class TestIndicatorSerializerForChildren:
         subcategory = pi.subcategory
         data = IndicatorDataSerializerForChildren(profile, root_geo, version2)
         pi_data = data[category.name]["subcategories"][subcategory.name]["indicators"][pi.label]["data"]
+        assert len(pi_data) == 2
         assert "WC" in pi_data
         assert "EC" in pi_data
         assert pi_data["WC"] == pi.indicator.indicatordata_set.get(geography__code="WC").data

--- a/tests/profile/serializers/test_indicator_data_for_children.py
+++ b/tests/profile/serializers/test_indicator_data_for_children.py
@@ -149,6 +149,8 @@ class TestIndicatorSerializerForChildren:
         subcategory = pi.subcategory
         data = IndicatorDataSerializerForChildren(profile, root_geo, version1)
         pi_data = data[category.name]["subcategories"][subcategory.name]["indicators"][pi.label]["data"]
+        assert len(pi_data) == 1
+        assert "EC" not in pi_data
         assert "WC" in pi_data
         assert pi_data["WC"] == pi.indicator.indicatordata_set.get(geography__code="WC").data
 

--- a/tests/profile/serializers/test_indicator_data_for_children.py
+++ b/tests/profile/serializers/test_indicator_data_for_children.py
@@ -1,0 +1,170 @@
+import pytest
+
+from tests.datasets.factories import (
+    GeographyFactory,
+    IndicatorDataFactory,
+    MetaDataFactory,
+    DatasetFactory,
+    IndicatorFactory,
+    VersionFactory,
+    GeographyHierarchyFactory,
+    GroupFactory
+)
+from tests.profile.factories import (
+    ProfileFactory,
+    ProfileIndicatorFactory,
+    IndicatorCategoryFactory,
+    IndicatorSubcategoryFactory
+)
+
+from tests.boundaries.factories import GeographyBoundaryFactory
+
+from wazimap_ng.datasets.models import Group, Geography
+from wazimap_ng.profile.models import Profile
+from wazimap_ng.profile.serializers import IndicatorDataSerializerForChildren
+
+@pytest.fixture
+def root_geo():
+    return Geography.add_root(code="ZA", level="country")
+
+@pytest.fixture
+def geo1(root_geo):
+    return root_geo.add_child(code="WC", level="province")
+
+@pytest.fixture
+def geo2(root_geo):
+    return root_geo.add_child(code="EC", level="province")
+
+@pytest.fixture
+def version1():
+    return VersionFactory(name="v1")
+
+@pytest.fixture
+def version2():
+    return VersionFactory(name="v2")
+
+@pytest.fixture
+def create_boundaries(root_geo, geo1, geo2, version1, version2):
+    """
+    Root belongs to version1 & version2
+    geo1 belongs to version1 & version2
+    geo2 only belongs to version2
+    """
+    GeographyBoundaryFactory(geography=root_geo, version=version1)
+    GeographyBoundaryFactory(geography=root_geo, version=version2)
+    GeographyBoundaryFactory(geography=geo1, version=version1)
+    GeographyBoundaryFactory(geography=geo1, version=version2)
+    GeographyBoundaryFactory(geography=geo2, version=version2)
+
+
+@pytest.fixture
+def geography_hierarchy(version1, version2, root_geo):
+    return GeographyHierarchyFactory(
+        root_geography=root_geo,
+        configuration = {
+            "default_version": version1.name,
+            "versions": [version1.name, version2.name]
+        }
+    )
+
+@pytest.fixture
+def profile(geography_hierarchy):
+    return ProfileFactory(
+        name="profile",
+        geography_hierarchy=geography_hierarchy
+    )
+
+@pytest.fixture
+def profile_indicators(profile, version1, version2):
+    datasetv1 = DatasetFactory(profile=profile, version=version1)
+    datasetv2 = DatasetFactory(profile=profile, version=version2)
+    GroupFactory(
+        dataset=datasetv1, name="gender", subindicators=["male", "female"],
+        can_aggregate=True, can_filter=True
+    )
+    GroupFactory(
+        dataset=datasetv1, name="language",
+        subindicators=["isiXhosa", "isiZulu"], can_aggregate=True, can_filter=True
+    )
+    GroupFactory(
+        dataset=datasetv2, name="gender", subindicators=["male", "female"],
+        can_aggregate=True, can_filter=True
+    )
+    GroupFactory(
+        dataset=datasetv2, name="language",
+        subindicators=["isiXhosa", "isiZulu"], can_aggregate=True, can_filter=True
+    )
+    indicatorv1 = IndicatorFactory(dataset=datasetv1)
+    indicatorv2 = IndicatorFactory(dataset=datasetv2)
+    category = IndicatorCategoryFactory(profile=profile)
+    subcategory = IndicatorSubcategoryFactory(category=category)
+    pi1 = ProfileIndicatorFactory(
+        profile=profile, label="PI1", subcategory=subcategory,
+        indicator=indicatorv1
+    )
+    pi2 = ProfileIndicatorFactory(
+        profile=profile, label="PI2", subcategory=subcategory,
+        indicator=indicatorv2
+    )
+    return [
+        pi1, pi2
+    ]
+
+@pytest.fixture
+def indicator_data(geo1, geo2, profile_indicators, indicatordata_json):
+    for pi in profile_indicators:
+        IndicatorDataFactory(
+            geography=geo1, indicator=pi.indicator, data=indicatordata_json
+        )
+        IndicatorDataFactory(
+            geography=geo2, indicator=pi.indicator, data=indicatordata_json
+        )
+
+@pytest.fixture
+def indicator_data_geo2(geo2, profile_indicators, indicatordata_json):
+    idata = []
+    for pi in profile_indicators:
+        idatum = IndicatorDataFactory(
+            geography=geo2, indicator=pi.indicator, data=indicatordata_json
+        )
+        idata.append(indicatordata_json)
+    return idata
+
+@pytest.mark.django_db
+class TestIndicatorSerializerForChildren:
+    def test_children_indicator_data_for_version1(
+        self, profile, root_geo, version1, profile_indicators, create_boundaries,
+        indicator_data,
+    ):
+        """
+        For version1
+        geography access : root_geo(ZA) & geo1(WC)
+        In this  case we should only get data for geo1
+        """
+        pi = profile_indicators[0]
+        category = pi.subcategory.category
+        subcategory =pi.subcategory
+        data = IndicatorDataSerializerForChildren(profile, root_geo, version1)
+        pi_data = data[category.name]["subcategories"][subcategory.name]["indicators"][pi.label]["data"]
+        assert "WC" in pi_data
+        assert pi_data["WC"] == pi.indicator.indicatordata_set.get(geography__code="WC").data
+
+    def test_children_indicator_data_for_version2(
+        self, profile, root_geo, version2, profile_indicators, create_boundaries,
+        indicator_data
+    ):
+        """
+        For version2
+        geography access : root_geo(ZA) & geo1(WC), geo2(EC)
+        In this  case we should only get data for geo1 & geo2
+        """
+        pi = profile_indicators[1]
+        category = pi.subcategory.category
+        subcategory = pi.subcategory
+        data = IndicatorDataSerializerForChildren(profile, root_geo, version2)
+        print(dict(data))
+        pi_data = data[category.name]["subcategories"][subcategory.name]["indicators"][pi.label]["data"]
+        assert "WC" in pi_data
+        assert "EC" in pi_data
+        assert pi_data["WC"] == pi.indicator.indicatordata_set.get(geography__code="WC").data
+        assert pi_data["EC"] == pi.indicator.indicatordata_set.get(geography__code="EC").data

--- a/tests/profile/serializers/test_indicator_data_serializer.py
+++ b/tests/profile/serializers/test_indicator_data_serializer.py
@@ -193,7 +193,7 @@ class TestExtendedProfileSerializer:
         geography = indicator.indicatordata_set.first().geography
 
         data = ExtendedProfileSerializer(
-            profile, geography, version, indicator_children=True
+            profile, geography, version, skip_children=False
         )
 
         # assert logo

--- a/tests/profile/serializers/test_indicator_data_serializer.py
+++ b/tests/profile/serializers/test_indicator_data_serializer.py
@@ -16,12 +16,14 @@ from tests.profile.factories import (
 from wazimap_ng.datasets.models.group import Group
 from wazimap_ng.profile.models import Profile
 from wazimap_ng.profile.serializers.indicator_data_serializer import (
-    IndicatorDataSerializer,
+    IndicatorDataSerializer
+)
+from wazimap_ng.profile.serializers.utils import (
     get_dataset_groups,
     get_profile_data
 )
-from wazimap_ng.profile.serializers.profile_indicator_serializer import (
-    FullProfileIndicatorSerializer
+from wazimap_ng.profile.serializers import (
+    FullProfileIndicatorSerializer, ExtendedProfileSerializer
 )
 
 
@@ -76,7 +78,6 @@ class TestGetProfileData:
 
         version = geography.geographyboundary_set.get().version
         output = get_profile_data(profile, [geography], version)
-        print(output)
         assert output[0]["profile_indicator_label"] == "PI1"
         assert output[1]["profile_indicator_label"] == "PI2"
 
@@ -181,3 +182,54 @@ class TestFullProfileIndicatorSerializer:
         for g in geography.get_children():
             assert g.code in child_data
             assert indicator.indicatordata_set.get(geography=g).data == child_data[g.code]
+
+@pytest.mark.django_db
+class TestExtendedProfileSerializer:
+    def test_basic_serializer(
+        self, profile, profile_indicator, groups, indicatordata_json, child_indicatordata
+    ):
+        version = profile.geography_hierarchy.root_geography.geographyboundary_set.get().version
+        indicator = profile_indicator.indicator
+        geography = indicator.indicatordata_set.first().geography
+
+        data = ExtendedProfileSerializer(
+            profile, geography, version, indicator_children=True
+        )
+
+        # assert logo
+        assert "logo" in data
+        assert data["logo"]["url"] == "/"
+
+        # assert geography
+        assert "geography" in data
+        assert data["geography"]["code"] == geography.code
+
+        # assert profile data
+        assert "profile_data" in data
+        profile_data = data["profile_data"]
+
+        category_name = profile_indicator.subcategory.category.name
+        subcategory_name = profile_indicator.subcategory.name
+        assert category_name in profile_data
+        assert "subcategories" in profile_data[category_name]
+        assert subcategory_name in profile_data[category_name]["subcategories"]
+        assert "indicators" in profile_data[category_name]["subcategories"][subcategory_name]
+        indicator_data = profile_data[category_name]["subcategories"][subcategory_name]["indicators"]
+        assert "child_data" in indicator_data[profile_indicator.label]
+        assert "data" in indicator_data[profile_indicator.label]
+        assert indicator_data[profile_indicator.label]["data"] == indicatordata_json
+
+        # Assert child data
+        child_data = indicator_data[profile_indicator.label]["child_data"]
+        assert len(child_data) == 2
+        for g in geography.get_children():
+            assert g.code in child_data
+            assert indicator.indicatordata_set.get(geography=g).data == child_data[g.code]
+
+        # assert highlight
+        assert "highlights" in data
+        assert data["highlights"] == []
+
+        # assert overview
+        assert "overview" in data
+        assert data["overview"]["name"] == "Profile"

--- a/tests/profile/serializers/test_indicator_data_serializer_without_children.py
+++ b/tests/profile/serializers/test_indicator_data_serializer_without_children.py
@@ -1,0 +1,133 @@
+import pytest
+
+from tests.datasets.factories import (
+    GeographyFactory,
+    IndicatorDataFactory,
+    MetaDataFactory,
+    DatasetFactory,
+    IndicatorFactory,
+)
+from tests.profile.factories import (
+    ProfileFactory,
+    ProfileIndicatorFactory,
+    IndicatorCategoryFactory,
+    IndicatorSubcategoryFactory,
+)
+from wazimap_ng.datasets.models.group import Group
+from wazimap_ng.profile.models import Profile
+from wazimap_ng.profile.serializers.indicator_data_serializer_without_children import (
+    IndicatorDataSerializerWithoutChildren
+)
+from wazimap_ng.profile.serializers.utils import (
+    get_dataset_groups,
+    get_profile_data
+)
+from wazimap_ng.profile.serializers.profile_serializer import (
+    ExtendedProfileSerializer
+)
+
+
+@pytest.fixture
+def profile_indicators(profile):
+    version = profile.geography_hierarchy.root_geography.geographyboundary_set.get().version
+    dataset1 = DatasetFactory(profile=profile, version=version)
+    dataset2 = DatasetFactory(profile=profile, version=version)
+    indicator1 = IndicatorFactory(dataset=dataset1)
+    indicator2 = IndicatorFactory(dataset=dataset2)
+    category = IndicatorCategoryFactory(profile=profile)
+    subcategory = IndicatorSubcategoryFactory(category=category)
+    pi1 = ProfileIndicatorFactory(profile=profile, label="PI1", subcategory=subcategory)
+    pi2 = ProfileIndicatorFactory(profile=profile, label="PI2", subcategory=subcategory)
+    return [
+        pi1, pi2
+    ]
+
+
+@pytest.fixture
+def indicator_data(geography, profile_indicators, version):
+    idata = []
+    for pi in profile_indicators:
+        dataset = pi.indicator.dataset
+        dataset.version = version
+        dataset.save()
+        indicator = pi.indicator
+        idatum = IndicatorDataFactory(geography=geography, indicator=indicator)
+        idata.append(idatum)
+
+    return idata
+
+
+@pytest.fixture
+def metadata(indicator_data):
+    dataset = indicator_data[0].indicator.dataset
+    return MetaDataFactory(
+        source="A source", url="http://example.com",
+        description="A description", dataset=dataset
+    )
+
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("groups")
+class TestIndicatorSerializerWithoutChildren:
+    def test(self, profile, geography, version, profile_indicator, category, subcategory):
+        serializer = IndicatorDataSerializerWithoutChildren(profile, geography, version)
+        pi_data = serializer[category.name]["subcategories"][subcategory.name]["indicators"][profile_indicator.label]
+        assert pi_data["id"] == profile_indicator.id
+        assert pi_data["dataset_content_type"] == "quantitative"
+
+@pytest.mark.django_db
+@pytest.mark.usefixtures("qualitative_groups")
+class TestQualitativeData:
+
+    @pytest.mark.usefixtures("qualitative_indicatordata")
+    def test_with_qualitative_data(self, profile, geography, version, qualitative_profile_indicator):
+        serializer = IndicatorDataSerializerWithoutChildren(profile, geography, version)
+        subcategory = qualitative_profile_indicator.subcategory
+        pi_data = serializer[subcategory.category.name]["subcategories"][subcategory.name]["indicators"][qualitative_profile_indicator.label]
+        assert pi_data["dataset_content_type"] == "qualitative"
+        assert pi_data["data"] == [{'content': 'This is example text'}, {'content': 'www.test.com'}]
+
+
+@pytest.mark.django_db
+class TestExtendedProfileSerializer:
+    def test_basic_serializer(
+        self, profile, profile_indicator, groups, indicatordata_json
+    ):
+        version = profile.geography_hierarchy.root_geography.geographyboundary_set.get().version
+        indicator = profile_indicator.indicator
+        geography = indicator.indicatordata_set.first().geography
+
+        data = ExtendedProfileSerializer(
+            profile, geography, version, indicator_children=False
+        )
+
+        # assert logo
+        assert "logo" in data
+        assert data["logo"]["url"] == "/"
+
+        # assert geography
+        assert "geography" in data
+        assert data["geography"]["code"] == geography.code
+
+        # assert profile data
+        assert "profile_data" in data
+        profile_data = data["profile_data"]
+
+        category_name = profile_indicator.subcategory.category.name
+        subcategory_name = profile_indicator.subcategory.name
+        assert category_name in profile_data
+        assert "subcategories" in profile_data[category_name]
+        assert subcategory_name in profile_data[category_name]["subcategories"]
+        assert "indicators" in profile_data[category_name]["subcategories"][subcategory_name]
+        indicator_data = profile_data[category_name]["subcategories"][subcategory_name]["indicators"]
+        assert "child_data" not in indicator_data[profile_indicator.label]
+        assert "data" in indicator_data[profile_indicator.label]
+        assert indicator_data[profile_indicator.label]["data"] == indicatordata_json
+
+        # assert highlight
+        assert "highlights" in data
+        assert data["highlights"] == []
+
+        # assert overview
+        assert "overview" in data
+        assert data["overview"]["name"] == "Profile"

--- a/tests/profile/serializers/test_indicator_data_serializer_without_children.py
+++ b/tests/profile/serializers/test_indicator_data_serializer_without_children.py
@@ -98,7 +98,7 @@ class TestExtendedProfileSerializer:
         geography = indicator.indicatordata_set.first().geography
 
         data = ExtendedProfileSerializer(
-            profile, geography, version, indicator_children=False
+            profile, geography, version, skip_children=True
         )
 
         # assert logo

--- a/wazimap_ng/datasets/admin/__init__.py
+++ b/wazimap_ng/datasets/admin/__init__.py
@@ -58,7 +58,8 @@ class GeographyHierarchyAdmin(HistoryAdmin):
     fieldsets = (
         ("", {
             "fields": (
-                "name", "root_geography", "description", "configuration"
+                "name", "root_geography", "description",
+                "configuration"
             )
         }),
     )

--- a/wazimap_ng/general/views.py
+++ b/wazimap_ng/general/views.py
@@ -63,14 +63,14 @@ def consolidated_profile(request, profile_id, geography_code):
 
 @condition(etag_func=etag_profile_updated, last_modified_func=last_modified_profile_updated)
 @api_view()
-def consolidated_profile_without_children(request, profile_id, geography_code):
+def consolidated_profile_for_specific_geography(request, profile_id, geography_code):
     version = request.GET.get('version', None)
     js = consolidated_profile_helper(profile_id, geography_code, version, False)
     return Response(js)
 
 @condition(etag_func=etag_profile_updated, last_modified_func=last_modified_profile_updated)
 @api_view()
-def consolidated_profile_only_for_children(request, profile_id, geography_code):
+def indicator_data_for_children(request, profile_id, geography_code):
     version_name = request.GET.get('version', None)
     profile = get_object_or_404(profile_models.Profile, pk=profile_id)
     if version_name is None:
@@ -81,7 +81,9 @@ def consolidated_profile_only_for_children(request, profile_id, geography_code):
         code=geography_code,
         geographyboundary__version=version
     )
-    profile_js = profile_serializers.IndicatorDataSerializerForChildren(profile, geography, version)
+    profile_js = profile_serializers.IndicatorDataSerializerForChildren(
+        profile, geography, version
+    )
     return Response(profile_js)
 
 

--- a/wazimap_ng/profile/serializers/__init__.py
+++ b/wazimap_ng/profile/serializers/__init__.py
@@ -5,6 +5,8 @@ from django.core.serializers import serialize
 
 from .. import models
 from .indicator_data_serializer import IndicatorDataSerializer
+from .indicator_data_serializer_without_children import IndicatorDataSerializerWithoutChildren
+from .indicator_data_serializer_for_children import IndicatorDataSerializerForChildren
 from .metrics_serializer import MetricsSerializer
 from .profile_logo import ProfileLogoSerializer
 from .overview_serializer import OverviewSerializer

--- a/wazimap_ng/profile/serializers/indicator_data_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer.py
@@ -1,81 +1,10 @@
 import logging
-from collections.abc import Iterable
-from itertools import groupby
-from typing import Dict
 
-from django.db.models import F
-
-from wazimap_ng.datasets.models import Dataset, Group, IndicatorData
-from wazimap_ng.profile.models import Profile
 from wazimap_ng.utils import expand_nested_list, mergedict, qsdict
-
 from .. import models
+from .utils import get_profile_data, get_dataset_groups, metadata_serializer
 
 logger = logging.getLogger(__name__)
-
-
-def get_profile_data(profile, geographies, version):
-    return get_indicator_data(profile, profile.indicators.all(), geographies, version)
-
-
-def get_indicator_data(profile, indicators, geographies, version):
-
-    data = (IndicatorData.objects
-            .filter(
-                indicator__in=indicators,
-                indicator__profileindicator__profile=profile,
-                geography__in=geographies,
-                indicator__dataset__version=version,
-            )
-            .values(
-                profile_indicator_id=F("indicator__profileindicator__id"),
-                jsdata=F("data"),
-                description=F("indicator__profileindicator__description"),
-                indicator_name=F("indicator__name"),
-                indicator_group=F("indicator__groups"),
-                profile_indicator_label=F("indicator__profileindicator__label"),
-                subcategory=F("indicator__profileindicator__subcategory__name"),
-                category=F("indicator__profileindicator__subcategory__category__name"),
-                choropleth_method=F("indicator__profileindicator__choropleth_method__name"),
-                dataset=F("indicator__dataset"),
-                version_name=F("indicator__dataset__version__name"),
-                metadata_source=F("indicator__dataset__metadata__source"),
-                metadata_description=F("indicator__dataset__metadata__description"),
-                metadata_url=F("indicator__dataset__metadata__url"),
-                dataset_content_type=F("indicator__dataset__content_type"),
-                licence_url=F("indicator__dataset__metadata__licence__url"),
-                licence_name=F("indicator__dataset__metadata__licence__name"),
-                indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
-                geography_code=F("geography__code"),
-                primary_group=F("indicator__groups"),
-                last_updated_at=F("indicator__profileindicator__updated"),
-                content_type=F("indicator__profileindicator__content_type"),
-            )
-            .order_by("indicator__profileindicator__order")
-            )
-
-    return data
-
-
-def get_dataset_groups(profile: Profile) -> Dict:
-    dataset_groups = (
-        Group.objects
-        .filter(dataset__indicator__profileindicator__profile=profile)
-        .values(
-            "subindicators",
-            "dataset",
-            "name",
-            "can_aggregate",
-            "can_filter"
-        ).order_by("dataset_id", "name").distinct("dataset_id", "name")
-    )
-
-    grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])
-    grouped_datasetdata = [(grouper, list(groups)) for grouper, groups in grouped_datasetdata]
-
-    dataset_groups_dict = dict(list(grouped_datasetdata))
-
-    return dataset_groups_dict
 
 
 def IndicatorDataSerializer(profile, geography, version):
@@ -105,34 +34,7 @@ def IndicatorDataSerializer(profile, geography, version):
 
     d_metadata = []
     for d in [children_indicator_data, indicator_data2]:
-        d_metadatum = qsdict(d,
-                             "category",
-                             lambda x: "subcategories",
-                             "subcategory",
-                             lambda x: "indicators",
-                             "profile_indicator_label",
-                             lambda x: {
-                                 "id": x["profile_indicator_id"],
-                                 "description": x["description"],
-                                 "choropleth_method": x["choropleth_method"],
-                                 "last_updated_at": x["last_updated_at"],
-                                 "metadata": {
-                                     "source": x["metadata_source"],
-                                     "description": x["metadata_description"],
-                                     "url": x["metadata_url"],
-                                     "licence": {
-                                         "name": x["licence_name"],
-                                         "url": x["licence_url"]
-                                     },
-                                     "primary_group": x["primary_group"][0],
-                                     "groups": dataset_groups_dict[x["dataset"]],
-                                 },
-                                 "content_type": x["content_type"],
-                                 "dataset_content_type": x["dataset_content_type"],
-                                 "version": x["version_name"],
-                                 "chart_configuration": x["indicator_chart_configuration"],
-                             },
-                             )
+        d_metadatum = metadata_serializer(d, dataset_groups_dict)
         d_metadata.append(d_metadatum)
 
     d4 = qsdict(indicator_data,

--- a/wazimap_ng/profile/serializers/indicator_data_serializer_for_children.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer_for_children.py
@@ -1,0 +1,80 @@
+import logging
+from collections.abc import Iterable
+from itertools import groupby
+from typing import Dict
+
+from django.db.models import F
+
+from wazimap_ng.datasets.models import Dataset, Group, IndicatorData
+from wazimap_ng.profile.models import Profile
+from wazimap_ng.utils import expand_nested_list, mergedict, qsdict
+
+from .. import models
+
+logger = logging.getLogger(__name__)
+
+
+def get_profile_data(profile, geographies, version):
+    return get_indicator_data(profile, profile.indicators.all(), geographies, version)
+
+
+def get_indicator_data(profile, indicators, geographies, version):
+
+    data = (IndicatorData.objects
+            .filter(
+                indicator__in=indicators,
+                indicator__profileindicator__profile=profile,
+                geography__in=geographies,
+                indicator__dataset__version=version,
+            )
+            .values(
+                jsdata=F("data"),
+                profile_indicator_label=F("indicator__profileindicator__label"),
+                subcategory=F("indicator__profileindicator__subcategory__name"),
+                category=F("indicator__profileindicator__subcategory__category__name"),
+                dataset=F("indicator__dataset"),
+                geography_code=F("geography__code"),
+            )
+            .order_by("indicator__profileindicator__order")
+            )
+    return data
+
+
+def IndicatorDataSerializerForChildren(profile, geography, version):
+    children = geography.get_child_geographies(version)
+    children_indicator_data = get_profile_data(profile, children, version)
+
+    subcategories = (models.IndicatorSubcategory.objects.filter(category__profile=profile)
+                     .order_by("category__order", "order")
+                     .select_related("category")
+                     )
+
+    c = qsdict(subcategories,
+               lambda x: x.category.name,
+               lambda x: {"description": x.category.description}
+               )
+
+    s = qsdict(subcategories,
+               lambda x: x.category.name,
+               lambda x: "subcategories",
+               "name",
+               lambda x: {"description": x.description}
+               )
+
+    d5 = qsdict(children_indicator_data,
+                "category",
+                lambda x: "subcategories",
+                "subcategory",
+                lambda x: "indicators",
+                "profile_indicator_label",
+                lambda x: "data",
+                "geography_code",
+                "jsdata",
+                )
+
+    new_dict = {}
+    mergedict(new_dict, c)
+    mergedict(new_dict, s)
+    mergedict(new_dict, d5)
+
+    return new_dict

--- a/wazimap_ng/profile/serializers/indicator_data_serializer_for_children.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer_for_children.py
@@ -28,26 +28,95 @@ def get_indicator_data(profile, indicators, geographies, version):
                 indicator__dataset__version=version,
             )
             .values(
+                profile_indicator_id=F("indicator__profileindicator__id"),
                 jsdata=F("data"),
+                description=F("indicator__profileindicator__description"),
+                indicator_name=F("indicator__name"),
+                indicator_group=F("indicator__groups"),
                 profile_indicator_label=F("indicator__profileindicator__label"),
                 subcategory=F("indicator__profileindicator__subcategory__name"),
                 category=F("indicator__profileindicator__subcategory__category__name"),
+                choropleth_method=F("indicator__profileindicator__choropleth_method__name"),
                 dataset=F("indicator__dataset"),
+                version_name=F("indicator__dataset__version__name"),
+                metadata_source=F("indicator__dataset__metadata__source"),
+                metadata_description=F("indicator__dataset__metadata__description"),
+                metadata_url=F("indicator__dataset__metadata__url"),
+                dataset_content_type=F("indicator__dataset__content_type"),
+                licence_url=F("indicator__dataset__metadata__licence__url"),
+                licence_name=F("indicator__dataset__metadata__licence__name"),
+                indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
                 geography_code=F("geography__code"),
+                primary_group=F("indicator__groups"),
+                last_updated_at=F("indicator__profileindicator__updated"),
+                content_type=F("indicator__profileindicator__content_type"),
             )
             .order_by("indicator__profileindicator__order")
             )
     return data
 
 
+def get_dataset_groups(profile: Profile) -> Dict:
+    dataset_groups = (
+        Group.objects
+        .filter(dataset__indicator__profileindicator__profile=profile)
+        .values(
+            "subindicators",
+            "dataset",
+            "name",
+            "can_aggregate",
+            "can_filter"
+        ).order_by("dataset_id", "name").distinct("dataset_id", "name")
+    )
+
+    grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])
+    grouped_datasetdata = [(grouper, list(groups)) for grouper, groups in grouped_datasetdata]
+
+    dataset_groups_dict = dict(list(grouped_datasetdata))
+
+    return dataset_groups_dict
+
+
 def IndicatorDataSerializerForChildren(profile, geography, version):
     children = geography.get_child_geographies(version)
     children_indicator_data = get_profile_data(profile, children, version)
-
+    dataset_groups_dict = get_dataset_groups(profile)
     subcategories = (models.IndicatorSubcategory.objects.filter(category__profile=profile)
                      .order_by("category__order", "order")
                      .select_related("category")
                      )
+
+    d_metadata = []
+    for d in [children_indicator_data]:
+        d_metadatum = qsdict(d,
+                             "category",
+                             lambda x: "subcategories",
+                             "subcategory",
+                             lambda x: "indicators",
+                             "profile_indicator_label",
+                             lambda x: {
+                                 "id": x["profile_indicator_id"],
+                                 "description": x["description"],
+                                 "choropleth_method": x["choropleth_method"],
+                                 "last_updated_at": x["last_updated_at"],
+                                 "metadata": {
+                                     "source": x["metadata_source"],
+                                     "description": x["metadata_description"],
+                                     "url": x["metadata_url"],
+                                     "licence": {
+                                         "name": x["licence_name"],
+                                         "url": x["licence_url"]
+                                     },
+                                     "primary_group": x["primary_group"][0],
+                                     "groups": dataset_groups_dict[x["dataset"]],
+                                 },
+                                 "content_type": x["content_type"],
+                                 "dataset_content_type": x["dataset_content_type"],
+                                 "version": x["version_name"],
+                                 "chart_configuration": x["indicator_chart_configuration"],
+                             },
+                             )
+        d_metadata.append(d_metadatum)
 
     c = qsdict(subcategories,
                lambda x: x.category.name,
@@ -75,6 +144,7 @@ def IndicatorDataSerializerForChildren(profile, geography, version):
     new_dict = {}
     mergedict(new_dict, c)
     mergedict(new_dict, s)
+    mergedict(new_dict, d_metadata[0])
     mergedict(new_dict, d5)
 
     return new_dict

--- a/wazimap_ng/profile/serializers/indicator_data_serializer_for_children.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer_for_children.py
@@ -1,80 +1,10 @@
 import logging
-from collections.abc import Iterable
-from itertools import groupby
-from typing import Dict
 
-from django.db.models import F
-
-from wazimap_ng.datasets.models import Dataset, Group, IndicatorData
-from wazimap_ng.profile.models import Profile
 from wazimap_ng.utils import expand_nested_list, mergedict, qsdict
-
 from .. import models
+from .utils import get_profile_data, get_dataset_groups, metadata_serializer
 
 logger = logging.getLogger(__name__)
-
-
-def get_profile_data(profile, geographies, version):
-    return get_indicator_data(profile, profile.indicators.all(), geographies, version)
-
-
-def get_indicator_data(profile, indicators, geographies, version):
-
-    data = (IndicatorData.objects
-            .filter(
-                indicator__in=indicators,
-                indicator__profileindicator__profile=profile,
-                geography__in=geographies,
-                indicator__dataset__version=version,
-            )
-            .values(
-                profile_indicator_id=F("indicator__profileindicator__id"),
-                jsdata=F("data"),
-                description=F("indicator__profileindicator__description"),
-                indicator_name=F("indicator__name"),
-                indicator_group=F("indicator__groups"),
-                profile_indicator_label=F("indicator__profileindicator__label"),
-                subcategory=F("indicator__profileindicator__subcategory__name"),
-                category=F("indicator__profileindicator__subcategory__category__name"),
-                choropleth_method=F("indicator__profileindicator__choropleth_method__name"),
-                dataset=F("indicator__dataset"),
-                version_name=F("indicator__dataset__version__name"),
-                metadata_source=F("indicator__dataset__metadata__source"),
-                metadata_description=F("indicator__dataset__metadata__description"),
-                metadata_url=F("indicator__dataset__metadata__url"),
-                dataset_content_type=F("indicator__dataset__content_type"),
-                licence_url=F("indicator__dataset__metadata__licence__url"),
-                licence_name=F("indicator__dataset__metadata__licence__name"),
-                indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
-                geography_code=F("geography__code"),
-                primary_group=F("indicator__groups"),
-                last_updated_at=F("indicator__profileindicator__updated"),
-                content_type=F("indicator__profileindicator__content_type"),
-            )
-            .order_by("indicator__profileindicator__order")
-            )
-    return data
-
-
-def get_dataset_groups(profile: Profile) -> Dict:
-    dataset_groups = (
-        Group.objects
-        .filter(dataset__indicator__profileindicator__profile=profile)
-        .values(
-            "subindicators",
-            "dataset",
-            "name",
-            "can_aggregate",
-            "can_filter"
-        ).order_by("dataset_id", "name").distinct("dataset_id", "name")
-    )
-
-    grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])
-    grouped_datasetdata = [(grouper, list(groups)) for grouper, groups in grouped_datasetdata]
-
-    dataset_groups_dict = dict(list(grouped_datasetdata))
-
-    return dataset_groups_dict
 
 
 def IndicatorDataSerializerForChildren(profile, geography, version):
@@ -86,37 +16,9 @@ def IndicatorDataSerializerForChildren(profile, geography, version):
                      .select_related("category")
                      )
 
-    d_metadata = []
-    for d in [children_indicator_data]:
-        d_metadatum = qsdict(d,
-                             "category",
-                             lambda x: "subcategories",
-                             "subcategory",
-                             lambda x: "indicators",
-                             "profile_indicator_label",
-                             lambda x: {
-                                 "id": x["profile_indicator_id"],
-                                 "description": x["description"],
-                                 "choropleth_method": x["choropleth_method"],
-                                 "last_updated_at": x["last_updated_at"],
-                                 "metadata": {
-                                     "source": x["metadata_source"],
-                                     "description": x["metadata_description"],
-                                     "url": x["metadata_url"],
-                                     "licence": {
-                                         "name": x["licence_name"],
-                                         "url": x["licence_url"]
-                                     },
-                                     "primary_group": x["primary_group"][0],
-                                     "groups": dataset_groups_dict[x["dataset"]],
-                                 },
-                                 "content_type": x["content_type"],
-                                 "dataset_content_type": x["dataset_content_type"],
-                                 "version": x["version_name"],
-                                 "chart_configuration": x["indicator_chart_configuration"],
-                             },
-                             )
-        d_metadata.append(d_metadatum)
+    d_metadata = metadata_serializer(
+        children_indicator_data, dataset_groups_dict
+    )
 
     c = qsdict(subcategories,
                lambda x: x.category.name,
@@ -144,7 +46,7 @@ def IndicatorDataSerializerForChildren(profile, geography, version):
     new_dict = {}
     mergedict(new_dict, c)
     mergedict(new_dict, s)
-    mergedict(new_dict, d_metadata[0])
+    mergedict(new_dict, d_metadata)
     mergedict(new_dict, d5)
 
     return new_dict

--- a/wazimap_ng/profile/serializers/indicator_data_serializer_without_children.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer_without_children.py
@@ -1,81 +1,11 @@
 import logging
-from collections.abc import Iterable
-from itertools import groupby
-from typing import Dict
 
-from django.db.models import F
-
-from wazimap_ng.datasets.models import Dataset, Group, IndicatorData
-from wazimap_ng.profile.models import Profile
 from wazimap_ng.utils import expand_nested_list, mergedict, qsdict
 
 from .. import models
+from .utils import get_profile_data, get_dataset_groups, metadata_serializer
 
 logger = logging.getLogger(__name__)
-
-
-def get_profile_data(profile, geographies, version):
-    return get_indicator_data(profile, profile.indicators.all(), geographies, version)
-
-
-def get_indicator_data(profile, indicators, geographies, version):
-
-    data = (IndicatorData.objects
-            .filter(
-                indicator__in=indicators,
-                indicator__profileindicator__profile=profile,
-                geography__in=geographies,
-                indicator__dataset__version=version,
-            )
-            .values(
-                profile_indicator_id=F("indicator__profileindicator__id"),
-                jsdata=F("data"),
-                description=F("indicator__profileindicator__description"),
-                indicator_name=F("indicator__name"),
-                indicator_group=F("indicator__groups"),
-                profile_indicator_label=F("indicator__profileindicator__label"),
-                subcategory=F("indicator__profileindicator__subcategory__name"),
-                category=F("indicator__profileindicator__subcategory__category__name"),
-                choropleth_method=F("indicator__profileindicator__choropleth_method__name"),
-                dataset=F("indicator__dataset"),
-                version_name=F("indicator__dataset__version__name"),
-                metadata_source=F("indicator__dataset__metadata__source"),
-                metadata_description=F("indicator__dataset__metadata__description"),
-                metadata_url=F("indicator__dataset__metadata__url"),
-                dataset_content_type=F("indicator__dataset__content_type"),
-                licence_url=F("indicator__dataset__metadata__licence__url"),
-                licence_name=F("indicator__dataset__metadata__licence__name"),
-                indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
-                geography_code=F("geography__code"),
-                primary_group=F("indicator__groups"),
-                last_updated_at=F("indicator__profileindicator__updated"),
-                content_type=F("indicator__profileindicator__content_type"),
-            )
-            .order_by("indicator__profileindicator__order")
-            )
-
-    return data
-
-
-def get_dataset_groups(profile: Profile) -> Dict:
-    dataset_groups = (
-        Group.objects
-        .filter(dataset__indicator__profileindicator__profile=profile)
-        .values(
-            "subindicators",
-            "dataset",
-            "name",
-            "can_aggregate",
-            "can_filter"
-        ).order_by("dataset_id", "name").distinct("dataset_id", "name")
-    )
-
-    grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])
-    grouped_datasetdata = [(grouper, list(groups)) for grouper, groups in grouped_datasetdata]
-
-    dataset_groups_dict = dict(list(grouped_datasetdata))
-
-    return dataset_groups_dict
 
 
 def IndicatorDataSerializerWithoutChildren(profile, geography, version):
@@ -89,6 +19,10 @@ def IndicatorDataSerializerWithoutChildren(profile, geography, version):
                      .select_related("category")
                      )
 
+    d_metadata = metadata_serializer(
+        indicator_data2, dataset_groups_dict
+    )
+
     c = qsdict(subcategories,
                lambda x: x.category.name,
                lambda x: {"description": x.category.description}
@@ -101,37 +35,6 @@ def IndicatorDataSerializerWithoutChildren(profile, geography, version):
                lambda x: {"description": x.description}
                )
 
-    d_metadata = []
-    for d in [indicator_data2]:
-        d_metadatum = qsdict(d,
-                             "category",
-                             lambda x: "subcategories",
-                             "subcategory",
-                             lambda x: "indicators",
-                             "profile_indicator_label",
-                             lambda x: {
-                                 "id": x["profile_indicator_id"],
-                                 "description": x["description"],
-                                 "choropleth_method": x["choropleth_method"],
-                                 "last_updated_at": x["last_updated_at"],
-                                 "metadata": {
-                                     "source": x["metadata_source"],
-                                     "description": x["metadata_description"],
-                                     "url": x["metadata_url"],
-                                     "licence": {
-                                         "name": x["licence_name"],
-                                         "url": x["licence_url"]
-                                     },
-                                     "primary_group": x["primary_group"][0],
-                                     "groups": dataset_groups_dict[x["dataset"]],
-                                 },
-                                 "content_type": x["content_type"],
-                                 "dataset_content_type": x["dataset_content_type"],
-                                 "version": x["version_name"],
-                                 "chart_configuration": x["indicator_chart_configuration"],
-                             },
-                             )
-        d_metadata.append(d_metadatum)
 
     d4 = qsdict(indicator_data,
                 "category",
@@ -146,7 +49,7 @@ def IndicatorDataSerializerWithoutChildren(profile, geography, version):
     new_dict = {}
     mergedict(new_dict, c)
     mergedict(new_dict, s)
-    mergedict(new_dict, d_metadata[0])
+    mergedict(new_dict, d_metadata)
     mergedict(new_dict, d4)
 
     return new_dict

--- a/wazimap_ng/profile/serializers/indicator_data_serializer_without_children.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer_without_children.py
@@ -1,0 +1,152 @@
+import logging
+from collections.abc import Iterable
+from itertools import groupby
+from typing import Dict
+
+from django.db.models import F
+
+from wazimap_ng.datasets.models import Dataset, Group, IndicatorData
+from wazimap_ng.profile.models import Profile
+from wazimap_ng.utils import expand_nested_list, mergedict, qsdict
+
+from .. import models
+
+logger = logging.getLogger(__name__)
+
+
+def get_profile_data(profile, geographies, version):
+    return get_indicator_data(profile, profile.indicators.all(), geographies, version)
+
+
+def get_indicator_data(profile, indicators, geographies, version):
+
+    data = (IndicatorData.objects
+            .filter(
+                indicator__in=indicators,
+                indicator__profileindicator__profile=profile,
+                geography__in=geographies,
+                indicator__dataset__version=version,
+            )
+            .values(
+                profile_indicator_id=F("indicator__profileindicator__id"),
+                jsdata=F("data"),
+                description=F("indicator__profileindicator__description"),
+                indicator_name=F("indicator__name"),
+                indicator_group=F("indicator__groups"),
+                profile_indicator_label=F("indicator__profileindicator__label"),
+                subcategory=F("indicator__profileindicator__subcategory__name"),
+                category=F("indicator__profileindicator__subcategory__category__name"),
+                choropleth_method=F("indicator__profileindicator__choropleth_method__name"),
+                dataset=F("indicator__dataset"),
+                version_name=F("indicator__dataset__version__name"),
+                metadata_source=F("indicator__dataset__metadata__source"),
+                metadata_description=F("indicator__dataset__metadata__description"),
+                metadata_url=F("indicator__dataset__metadata__url"),
+                dataset_content_type=F("indicator__dataset__content_type"),
+                licence_url=F("indicator__dataset__metadata__licence__url"),
+                licence_name=F("indicator__dataset__metadata__licence__name"),
+                indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
+                geography_code=F("geography__code"),
+                primary_group=F("indicator__groups"),
+                last_updated_at=F("indicator__profileindicator__updated"),
+                content_type=F("indicator__profileindicator__content_type"),
+            )
+            .order_by("indicator__profileindicator__order")
+            )
+
+    return data
+
+
+def get_dataset_groups(profile: Profile) -> Dict:
+    dataset_groups = (
+        Group.objects
+        .filter(dataset__indicator__profileindicator__profile=profile)
+        .values(
+            "subindicators",
+            "dataset",
+            "name",
+            "can_aggregate",
+            "can_filter"
+        ).order_by("dataset_id", "name").distinct("dataset_id", "name")
+    )
+
+    grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])
+    grouped_datasetdata = [(grouper, list(groups)) for grouper, groups in grouped_datasetdata]
+
+    dataset_groups_dict = dict(list(grouped_datasetdata))
+
+    return dataset_groups_dict
+
+
+def IndicatorDataSerializerWithoutChildren(profile, geography, version):
+    indicator_data = get_profile_data(profile, [geography], version)
+
+    dataset_groups_dict = get_dataset_groups(profile)
+    indicator_data2 = list(expand_nested_list(indicator_data, "jsdata"))
+
+    subcategories = (models.IndicatorSubcategory.objects.filter(category__profile=profile)
+                     .order_by("category__order", "order")
+                     .select_related("category")
+                     )
+
+    c = qsdict(subcategories,
+               lambda x: x.category.name,
+               lambda x: {"description": x.category.description}
+               )
+
+    s = qsdict(subcategories,
+               lambda x: x.category.name,
+               lambda x: "subcategories",
+               "name",
+               lambda x: {"description": x.description}
+               )
+
+    d_metadata = []
+    for d in [indicator_data2]:
+        d_metadatum = qsdict(d,
+                             "category",
+                             lambda x: "subcategories",
+                             "subcategory",
+                             lambda x: "indicators",
+                             "profile_indicator_label",
+                             lambda x: {
+                                 "id": x["profile_indicator_id"],
+                                 "description": x["description"],
+                                 "choropleth_method": x["choropleth_method"],
+                                 "last_updated_at": x["last_updated_at"],
+                                 "metadata": {
+                                     "source": x["metadata_source"],
+                                     "description": x["metadata_description"],
+                                     "url": x["metadata_url"],
+                                     "licence": {
+                                         "name": x["licence_name"],
+                                         "url": x["licence_url"]
+                                     },
+                                     "primary_group": x["primary_group"][0],
+                                     "groups": dataset_groups_dict[x["dataset"]],
+                                 },
+                                 "content_type": x["content_type"],
+                                 "dataset_content_type": x["dataset_content_type"],
+                                 "version": x["version_name"],
+                                 "chart_configuration": x["indicator_chart_configuration"],
+                             },
+                             )
+        d_metadata.append(d_metadatum)
+
+    d4 = qsdict(indicator_data,
+                "category",
+                lambda x: "subcategories",
+                "subcategory",
+                lambda x: "indicators",
+                "profile_indicator_label",
+                lambda x: "data",
+                "jsdata",
+                )
+
+    new_dict = {}
+    mergedict(new_dict, c)
+    mergedict(new_dict, s)
+    mergedict(new_dict, d_metadata[0])
+    mergedict(new_dict, d4)
+
+    return new_dict

--- a/wazimap_ng/profile/serializers/profile_indicator_serializer.py
+++ b/wazimap_ng/profile/serializers/profile_indicator_serializer.py
@@ -5,7 +5,7 @@ from rest_framework import serializers
 from wazimap_ng.datasets.models import IndicatorData
 from wazimap_ng.profile.models import ProfileIndicator
 
-from .indicator_data_serializer import get_indicator_data
+from .utils import get_indicator_data
 
 import logging
 

--- a/wazimap_ng/profile/serializers/profile_serializer.py
+++ b/wazimap_ng/profile/serializers/profile_serializer.py
@@ -6,7 +6,10 @@ from wazimap_ng.datasets.serializers import AncestorGeographySerializer
 from wazimap_ng.datasets.serializers import GeographyHierarchySerializer
 from wazimap_ng.cms.serializers import ContentSerializer
 from .. import models
-from . import IndicatorDataSerializer, MetricsSerializer, ProfileLogoSerializer, HighlightsSerializer, OverviewSerializer
+from . import (
+    IndicatorDataSerializer, MetricsSerializer, ProfileLogoSerializer,
+    HighlightsSerializer, OverviewSerializer, IndicatorDataSerializerWithoutChildren
+)
 from . import ProfileIndicatorSerializer
 
 class SimpleProfileSerializer(serializers.ModelSerializer):
@@ -37,10 +40,13 @@ class ProfileSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'permission_type', 'requires_authentication', 'geography_hierarchy', 'description', 'configuration')
 
 
-def ExtendedProfileSerializer(profile, geography, version):
+def ExtendedProfileSerializer(profile, geography, version, indicator_children=True):
     models.ProfileKeyMetrics.objects.filter(subcategory__category__profile=profile)
 
-    profile_data = IndicatorDataSerializer(profile, geography, version)
+    if indicator_children:
+        profile_data = IndicatorDataSerializer(profile, geography, version)
+    else:
+        profile_data = IndicatorDataSerializerWithoutChildren(profile, geography, version)
     metrics_data = MetricsSerializer(profile, geography, version)
     logo_json = ProfileLogoSerializer(profile)
     highlights = HighlightsSerializer(profile, geography, version)

--- a/wazimap_ng/profile/serializers/profile_serializer.py
+++ b/wazimap_ng/profile/serializers/profile_serializer.py
@@ -40,13 +40,13 @@ class ProfileSerializer(serializers.ModelSerializer):
         fields = ('id', 'name', 'permission_type', 'requires_authentication', 'geography_hierarchy', 'description', 'configuration')
 
 
-def ExtendedProfileSerializer(profile, geography, version, indicator_children=True):
+def ExtendedProfileSerializer(profile, geography, version, skip_children=False):
     models.ProfileKeyMetrics.objects.filter(subcategory__category__profile=profile)
-
-    if indicator_children:
-        profile_data = IndicatorDataSerializer(profile, geography, version)
-    else:
+    if skip_children:
         profile_data = IndicatorDataSerializerWithoutChildren(profile, geography, version)
+    else:
+        profile_data = IndicatorDataSerializer(profile, geography, version)
+
     metrics_data = MetricsSerializer(profile, geography, version)
     logo_json = ProfileLogoSerializer(profile)
     highlights = HighlightsSerializer(profile, geography, version)

--- a/wazimap_ng/profile/serializers/utils.py
+++ b/wazimap_ng/profile/serializers/utils.py
@@ -1,0 +1,100 @@
+from itertools import groupby
+from typing import Dict
+
+from django.db.models import F
+
+from wazimap_ng.datasets.models import Group, IndicatorData
+from wazimap_ng.profile.models import Profile
+from wazimap_ng.utils import qsdict
+
+
+def get_indicator_data(profile, indicators, geographies, version):
+
+    data = (IndicatorData.objects
+            .filter(
+                indicator__in=indicators,
+                indicator__profileindicator__profile=profile,
+                geography__in=geographies,
+                indicator__dataset__version=version,
+            )
+            .values(
+                profile_indicator_id=F("indicator__profileindicator__id"),
+                jsdata=F("data"),
+                description=F("indicator__profileindicator__description"),
+                indicator_name=F("indicator__name"),
+                indicator_group=F("indicator__groups"),
+                profile_indicator_label=F("indicator__profileindicator__label"),
+                subcategory=F("indicator__profileindicator__subcategory__name"),
+                category=F("indicator__profileindicator__subcategory__category__name"),
+                choropleth_method=F("indicator__profileindicator__choropleth_method__name"),
+                dataset=F("indicator__dataset"),
+                version_name=F("indicator__dataset__version__name"),
+                metadata_source=F("indicator__dataset__metadata__source"),
+                metadata_description=F("indicator__dataset__metadata__description"),
+                metadata_url=F("indicator__dataset__metadata__url"),
+                dataset_content_type=F("indicator__dataset__content_type"),
+                licence_url=F("indicator__dataset__metadata__licence__url"),
+                licence_name=F("indicator__dataset__metadata__licence__name"),
+                indicator_chart_configuration=F("indicator__profileindicator__chart_configuration"),
+                geography_code=F("geography__code"),
+                primary_group=F("indicator__groups"),
+                last_updated_at=F("indicator__profileindicator__updated"),
+                content_type=F("indicator__profileindicator__content_type"),
+            )
+            .order_by("indicator__profileindicator__order")
+            )
+
+    return data
+
+def get_profile_data(profile, geographies, version):
+    return get_indicator_data(profile, profile.indicators.all(), geographies, version)
+
+def get_dataset_groups(profile: Profile) -> Dict:
+    dataset_groups = (
+        Group.objects
+        .filter(dataset__indicator__profileindicator__profile=profile)
+        .values(
+            "subindicators",
+            "dataset",
+            "name",
+            "can_aggregate",
+            "can_filter"
+        ).order_by("dataset_id", "name").distinct("dataset_id", "name")
+    )
+
+    grouped_datasetdata = groupby(dataset_groups, lambda g: g["dataset"])
+    grouped_datasetdata = [(grouper, list(groups)) for grouper, groups in grouped_datasetdata]
+
+    dataset_groups_dict = dict(list(grouped_datasetdata))
+
+    return dataset_groups_dict
+
+def metadata_serializer(obj, dataset_groups_dict):
+    return qsdict(obj,
+         "category",
+         lambda x: "subcategories",
+         "subcategory",
+         lambda x: "indicators",
+         "profile_indicator_label",
+         lambda x: {
+             "id": x["profile_indicator_id"],
+             "description": x["description"],
+             "choropleth_method": x["choropleth_method"],
+             "last_updated_at": x["last_updated_at"],
+             "metadata": {
+                 "source": x["metadata_source"],
+                 "description": x["metadata_description"],
+                 "url": x["metadata_url"],
+                 "licence": {
+                     "name": x["licence_name"],
+                     "url": x["licence_url"]
+                 },
+                 "primary_group": x["primary_group"][0],
+                 "groups": dataset_groups_dict[x["dataset"]],
+             },
+             "content_type": x["content_type"],
+             "dataset_content_type": x["dataset_content_type"],
+             "version": x["version_name"],
+             "chart_configuration": x["indicator_chart_configuration"],
+         },
+     )

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -167,7 +167,7 @@ urlpatterns = [
     path(
         "api/v1/children-indicators/profile/<int:profile_id>/geography/<str:geography_code>/",
         cache(general_views.indicator_data_for_children),
-        name="all-details2"
+        name="children-indicators"
     ),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -160,11 +160,6 @@ urlpatterns = [
     path("api/v1/tasks/<str:task_id>/", task_status, name="task_status"),
     path('sentry-debug/', trigger_error),
     path(
-        "api/v1/all_details2/profile/<int:profile_id>/geography/<str:geography_code>/",
-        cache(general_views.consolidated_profile_for_specific_geography),
-        name="all-details2"
-    ),
-    path(
         "api/v1/children-indicators/profile/<int:profile_id>/geography/<str:geography_code>/",
         cache(general_views.indicator_data_for_children),
         name="children-indicators"

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -161,12 +161,12 @@ urlpatterns = [
     path('sentry-debug/', trigger_error),
     path(
         "api/v1/all_details2/profile/<int:profile_id>/geography/<str:geography_code>/",
-        cache(general_views.consolidated_profile_without_children),
+        cache(general_views.consolidated_profile_for_specific_geography),
         name="all-details2"
     ),
     path(
         "api/v1/children-indicators/profile/<int:profile_id>/geography/<str:geography_code>/",
-        cache(general_views.consolidated_profile_only_for_children),
+        cache(general_views.indicator_data_for_children),
         name="all-details2"
     ),
 

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -159,6 +159,16 @@ urlpatterns = [
     ),
     path("api/v1/tasks/<str:task_id>/", task_status, name="task_status"),
     path('sentry-debug/', trigger_error),
+    path(
+        "api/v1/all_details2/profile/<int:profile_id>/geography/<str:geography_code>/",
+        cache(general_views.consolidated_profile_without_children),
+        name="all-details2"
+    ),
+    path(
+        "api/v1/children-indicators/profile/<int:profile_id>/geography/<str:geography_code>/",
+        cache(general_views.consolidated_profile_only_for_children),
+        name="all-details2"
+    ),
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 


### PR DESCRIPTION
## Description
Separating Child indicators from all_details

**Key Points:**
* Not removing `all_details` yet
* Adding new api endpoint : `all_details2` -> get all indicator data for geography excpet indicator data for child geographies
* Adding new api endpoint `children-indicators`-> get indicator data for child geographies
* Added new serializers and views for new api endpoints
* Reduced code redundancies as much as possible 

**Backend test list:**

all_details2:
* Copy over all all_details test to all_details2 and every test excluding test including child_data should pass
* Copy over tests for IndicatorDataSerializer and all should pass except the ones testing for child_data
* child_data not included in all_details2 either by writing a test for view or serializer

child-indicators:
* indicator data is returned for children for passed geography
* Children should change according to the version passed
* Copy over tests for child_data in views or serializer of all_details and check if they pass


**Added test:**

* TestExtendedProfileSerializer
There was no existing test for ExtendedProfileSerializer.
we are using this serializer in all_details and all_details2 so added a test named : TestExtendedProfileSerializer for both TestIndicatorData and TestIndicatorDataWithoutChildren. 
Adding in both places suggest that all data should be same for both request only diff is one should have child data and other shouldn’t

* TestIndicatorSerializerForChildren
   Test to check if geography inside profile indicator change according to the version passed
    Everything else is same in the api so do not need test as that data is coming from common function and is currently tested under all_details



## Related Issue
https://wazimap.atlassian.net/browse/WNCM-191

## How to test it locally
Load  these 3 api endpoints in tabs: 
* all_details: http://localhost:8000/api/v1/all_details/profile/1/geography/ZA/?format=json
*  all_details2: http://localhost:8000/api/v1/all_details2/profile/1/geography/ZA/?format=json
* children-indicators: http://localhost:8000/api/v1/all_details/profile/1/geography/ZA/?format=json

all_details should have `profile_data -> category -> subcategory -> PI -> data & child_data`
all_details2 should have only data and it should match with data in all_details `profile_data -> category -> subcategory -> PI -> data`
children-indicators should have `profile_data -> category -> subcategory -> PI -> data`
Here data should be all children of geography passed and it should match wxactly with child_data or all_details

## Changelog
* urls.py: added new urls
* general/views.py: Added new view for new endpoints
* profile/serializer/indicator_data_serializer.py: Modified it so there can be less code redundancies
* Added new serializers in profile app

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
