### PR TITLE
WNCM-235 : adding profile name to variable filter widget & setting its max width

### DIFF
--- a/wazimap_ng/datasets/models/indicator.py
+++ b/wazimap_ng/datasets/models/indicator.py
@@ -36,10 +36,10 @@ class Indicator(BaseModel, SimpleHistory):
             logger.debug(f"Updating subindicators for indicator: {self.name} ({self.id})")
             self.subindicators = self.get_unique_subindicators()
         super().save(*args, **kwargs)
-        
+
 
     def __str__(self):
-        return f"{self.dataset.name} -> {self.name}"
+        return f"{self.dataset.profile} : {self.dataset.name} -> {self.name}"
 
     class Meta:
         ordering = ["id"]

--- a/wazimap_ng/general/static/css/variable-filter-widget.css
+++ b/wazimap_ng/general/static/css/variable-filter-widget.css
@@ -19,3 +19,7 @@
 select[name="content_indicator"] {
   margin-left: 160px;
 }
+
+select#id_indicator{
+    max-width: 700px;
+}

--- a/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
+++ b/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
@@ -6,7 +6,7 @@
 {% for choice in choices %}
 	<option
 		value="{{ choice.id }}"
-        title="{{ choice }}"
+		title="{{ choice }}"
 		data-type="{{ choice.dataset.permission_type }}"
 		class="{% if permission_type != choice.dataset.permission_type %} hidden {% endif %}"
 		{% if value.id == choice.id %} selected {% endif %}

--- a/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
+++ b/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
@@ -4,8 +4,9 @@
 <select id="id_indicator" required name="{{name}}">
 <option value=''>-------------</option>
 {% for choice in choices %}
-	<option 
+	<option
 		value="{{ choice.id }}"
+        title="{{ choice }}"
 		data-type="{{ choice.dataset.permission_type }}"
 		class="{% if permission_type != choice.dataset.permission_type %} hidden {% endif %}"
 		{% if value.id == choice.id %} selected {% endif %}


### PR DESCRIPTION
## Description
* Added profile name to indicator dropdown options
* Set a max-width for the dropdown and set the title attribute of the options

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-235

## How to test it locally

## Changelog

### Added

### Updated
* `wazimap_ng/datasets/models/indicator.py` to add the profile name 
* `wazimap_ng/general/static/css/variable-filter-widget.css` to set the max-width of the dropdown
* `wazimap_ng/general/templates/widgets/VariableFilterWidget.html` to set the `title` attribute of the options

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
