### PR TITLE
Added validations to make sure user can only select version from valid list according to profile selected

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,9 +42,19 @@ def profile_admin_group():
     return AuthGroupFactory(name="ProfileAdmin")
 
 @pytest.fixture
+def data_admin_group():
+    return AuthGroupFactory(name="DataAdmin")
+
+@pytest.fixture
 def profile_admin_user(profile_admin_group):
     user = UserFactory(is_staff=True)
     user.groups.add(profile_admin_group)
+    return user
+
+@pytest.fixture
+def data_admin_user(data_admin_group):
+    user = UserFactory(is_staff=True)
+    user.groups.add(data_admin_group)
     return user
 
 @pytest.fixture
@@ -68,6 +78,13 @@ def mocked_request_profileadmin(factory, profile_admin_user):
     request = factory.get('/get/request')
     request.method = 'GET'
     request.user = profile_admin_user
+    return request
+
+@pytest.fixture
+def mocked_request_dataadmin(factory, data_admin_user):
+    request = factory.get('/get/request')
+    request.method = 'GET'
+    request.user = data_admin_user
     return request
 
 

--- a/tests/datasets/admin/test_dataset_admin.py
+++ b/tests/datasets/admin/test_dataset_admin.py
@@ -1,0 +1,284 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.urls import reverse
+from django.core.exceptions import ValidationError
+
+from wazimap_ng.datasets.admin.dataset_admin import DatasetAdmin
+from wazimap_ng.datasets.admin.forms import DatasetAdminForm
+
+from wazimap_ng.datasets.models import Dataset, Version
+
+from tests.datasets.factories import (
+    DatasetFactory,
+    GeographyHierarchyFactory,
+    VersionFactory
+)
+from tests.profile.factories import ProfileFactory
+
+
+@pytest.fixture
+def version1():
+    return VersionFactory(name="version1")
+
+@pytest.fixture
+def version2():
+    return VersionFactory(name="version2")
+
+@pytest.fixture
+def multiversion_hierarchy(child_geographies, version1, version2):
+    hierarchy = GeographyHierarchyFactory(
+        root_geography=child_geographies[0],
+        configuration = {
+            "default_version": version1.name,
+            "versions": [version1.name, version2.name]
+        }
+    )
+    return hierarchy
+
+@pytest.fixture
+def multiversion_profile(multiversion_hierarchy):
+    return ProfileFactory(geography_hierarchy=multiversion_hierarchy)
+
+
+@pytest.mark.django_db
+class TestDatasetAdmin:
+
+    def test_modeladmin_str(self):
+        admin_site = DatasetAdmin(Dataset, AdminSite())
+        assert str(admin_site) == 'datasets.DatasetAdmin'
+
+@pytest.mark.django_db
+class TestDatasetAdminInitialForm:
+
+    def test_profile_field_with_single_profile(
+        self, mocked_request, profile
+    ):
+        """
+        Test initial data when there is only one profile.
+        asserts:
+            * Profile should be selected automatically
+        """
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        form = dataset_admin.get_form(mocked_request)()
+
+        assert "profile" in form.fields
+        profile_form_field = form.fields["profile"]
+        assert profile_form_field.queryset.count() == 1
+        assert profile_form_field.queryset.first() == profile
+        assert profile_form_field.initial == profile
+
+    def test_profile_field_with_multiple_profiles(
+        self, mocked_request, profile, private_profile
+    ):
+        """
+        Test initial data when there are multiple profiles.
+        asserts:
+            * profile form field initial data should be None
+        """
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        form = dataset_admin.get_form(mocked_request)()
+
+        assert "profile" in form.fields
+        profile_form_field = form.fields["profile"]
+        assert profile_form_field.queryset.count() == 2
+        assert list(profile_form_field.queryset) == [profile, private_profile]
+        assert profile_form_field.initial == None
+
+    def test_version_field_with_single_profile_single_verion(
+        self, mocked_request, profile
+    ):
+        """
+        Test initial data when there are single profile linked to single version
+        asserts:
+            * Version queryset count should be one
+            * Version field intial value should be selected
+        """
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        form = dataset_admin.get_form(mocked_request)()
+
+        assert "version" in form.fields
+        version_form_field = form.fields["version"]
+        versions = Version.objects.filter(
+            name__in=profile.geography_hierarchy.get_version_names
+        )
+        assert version_form_field.queryset.count() == 1
+        assert version_form_field.queryset.first() == versions.first()
+        assert version_form_field.initial == versions.first()
+
+    def test_version_field_with_single_profile_multiple_verion(
+        self, mocked_request, multiversion_profile, version1, version2
+    ):
+        """
+        Test initial data when there are single profile linked to multiple version
+        asserts:
+            * Version queryset count should be 2
+            * Version field intial value should be None
+        """
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        form = dataset_admin.get_form(mocked_request)()
+
+        assert "version" in form.fields
+        version_form_field = form.fields["version"]
+        assert version_form_field.queryset.count() == 2
+        assert list(version_form_field.queryset) == [version1, version2]
+        assert version_form_field.initial == None
+
+    def test_version_field_with_multiple_profile_multiple_verion(
+        self, mocked_request, profile, private_profile
+    ):
+        """
+        Test initial version data when there are multiple profiles
+        asserts:
+            * Version queryset count should be 0
+            * Version field intial value should be None
+        """
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        form = dataset_admin.get_form(mocked_request)()
+
+        version_form_field = form.fields["version"]
+        assert version_form_field.queryset.count() == 0
+        assert version_form_field.initial == None
+
+    def test_profile_queryset_for_dataadmin(
+        self, mocked_request_dataadmin, data_admin_user, profile,
+        private_profile, profile_group
+    ):
+        """
+        Test profile queryset for dataadmin if:
+            * There are no profile group for dataadmin
+            * If there is profile group assigned to admin user
+        """
+        dataset_admin = DatasetAdmin(Dataset, AdminSite())
+        form = dataset_admin.get_form(mocked_request_dataadmin)()
+
+        # assert queryset 0 if admin user does not have profile in groups
+        profile_form_field = form.fields["profile"]
+        assert profile_form_field.queryset.count() == 0
+
+        # Add profile in qualitative_groups
+        data_admin_user.groups.add(profile_group)
+
+        form = dataset_admin.get_form(mocked_request_dataadmin)()
+        profile_form_field = form.fields["profile"]
+
+        # assert if profile is visible if added to group
+        assert profile_form_field.queryset.count() == 1
+        assert profile_form_field.queryset.first() == profile
+        assert profile_form_field.initial == profile
+
+@pytest.mark.django_db
+class TestDatasetAdminChangeForm:
+
+    def test_version_field_for_existing_object(
+        self, client, superuser, dataset, profile
+    ):
+        """
+        Test version queryset for existing dataset object
+        assert if version field queryset is set accoring to the selected
+        profile
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:datasets_dataset_change", args=(dataset.id,))
+        res = client.get(url, follow=True)
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+
+        assert dataset.profile == profile
+        # get versions of profile
+        versions = Version.objects.filter(
+            name__in=profile.geography_hierarchy.get_version_names
+        )
+        assert list(form.fields["version"].queryset) == list(versions)
+
+    def test_version_field_if_profile_is_changed(
+        self, client, superuser, dataset, multiversion_profile, profile
+    ):
+        """
+        Test version queryset when user is trying to change the profile
+        Assert if form.intial and form.data profile are different and version queryset
+        is set accoding to the profile in form.data
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:datasets_dataset_change", args=(dataset.id,))
+        data={
+            'profile': multiversion_profile.id,
+            'metadata-TOTAL_FORMS': 0,
+            'metadata-INITIAL_FORMS': 0,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+
+        # assert initial profile
+        assert dataset.profile == profile
+        assert form.initial["profile"] == profile.id
+
+        # assert profile in data
+        assert form.data["profile"] == str(multiversion_profile.id)
+        # get versions of multiversion profile
+        versions = Version.objects.filter(
+            name__in=multiversion_profile.geography_hierarchy.get_version_names
+        )
+
+        # assert versions
+        assert form.fields["version"].queryset.count() == 2
+        assert list(form.fields["version"].queryset) == list(versions)
+
+@pytest.mark.django_db
+class TestDatasetAdminFormValidations:
+
+    def test_validation_for_required_fields(
+        self, client, superuser
+    ):
+        """
+        Test validation for admin form required fields
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:datasets_dataset_add")
+        data={
+            'metadata-TOTAL_FORMS': 0,
+            'metadata-INITIAL_FORMS': 0,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+        errors = form.errors
+
+        error_fields = [
+            'profile', 'name', 'permission_type',
+            'version', 'content_type'
+        ]
+        assert list(errors.keys()) == error_fields
+
+        for field in error_fields:
+            assert errors[field].data[0].message == 'This field is required.'
+
+    def test_if_version_is_not_linked_to_selected_profile(
+        self, client, superuser, profile, version1
+    ):
+        """
+        Test validations for version field when selected version does not
+        match with versions present for profile
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:datasets_dataset_add")
+        data={
+            'profile': profile.id,
+            'version': version1.id,
+            'metadata-TOTAL_FORMS': 0,
+            'metadata-INITIAL_FORMS': 0,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+        errors = form.errors
+        assert errors["version"].data[0].message == 'Select a valid choice. That choice is not one of the available choices.'
+
+        # assert fallback with clean
+        form.cleaned_data = {"version": version1, "profile": profile}
+        with pytest.raises(ValidationError) as e_info:
+            form.clean()
+        assert str(e_info.value.args[0]) == 'Version version1 not valid for profile Profile'

--- a/tests/datasets/admin/test_dataset_admin.py
+++ b/tests/datasets/admin/test_dataset_admin.py
@@ -84,7 +84,7 @@ class TestDatasetAdminInitialForm:
         assert list(profile_form_field.queryset) == [profile, private_profile]
         assert profile_form_field.initial == None
 
-    def test_version_field_with_single_profile_single_verion(
+    def test_version_field_with_single_profile_single_version(
         self, mocked_request, profile
     ):
         """
@@ -105,7 +105,7 @@ class TestDatasetAdminInitialForm:
         assert version_form_field.queryset.first() == versions.first()
         assert version_form_field.initial == versions.first()
 
-    def test_version_field_with_single_profile_multiple_verion(
+    def test_version_field_with_single_profile_multiple_version(
         self, mocked_request, multiversion_profile, version1, version2
     ):
         """
@@ -123,7 +123,7 @@ class TestDatasetAdminInitialForm:
         assert list(version_form_field.queryset) == [version1, version2]
         assert version_form_field.initial == None
 
-    def test_version_field_with_multiple_profile_multiple_verion(
+    def test_version_field_with_multiple_profile_multiple_version(
         self, mocked_request, profile, private_profile
     ):
         """

--- a/wazimap_ng/datasets/admin/dataset_admin.py
+++ b/wazimap_ng/datasets/admin/dataset_admin.py
@@ -69,9 +69,11 @@ class DatasetAdmin(DatasetBaseAdminModel, HistoryAdmin):
 
     readonly_fields = ("imported_dataset", )
 
+    class Media:
+        js = ("/static/js/dataset-admin.js",)
+
 
     def imported_dataset(self, obj):
-
         def get_url(file_obj):
             return '<a href="%s">%s</a>' % (reverse(
                 'admin:%s_%s_change' % (

--- a/wazimap_ng/datasets/admin/forms/dataset_admin_form.py
+++ b/wazimap_ng/datasets/admin/forms/dataset_admin_form.py
@@ -3,6 +3,7 @@ from django import forms
 from wazimap_ng.general.services.permissions import get_user_group
 from wazimap_ng.general.admin.forms import HistoryAdminForm
 
+from wazimap_ng.datasets.models import Version
 
 class DatasetAdminForm(HistoryAdminForm):
     import_dataset = forms.FileField(required=False)
@@ -11,27 +12,52 @@ class DatasetAdminForm(HistoryAdminForm):
         cleaned_data = super(DatasetAdminForm, self).clean()
 
         profile = cleaned_data.get('profile', None)
-        permission_type = cleaned_data.get('permission_type', None)
+        version = cleaned_data.get('version', None)
 
-        if permission_type == 'private' and profile is None:
-            raise forms.ValidationError('Profile should be set for private permissions.')
+        if profile and version:
+            versions = self.get_versions(profile)
+            if version not in versions:
+                raise forms.ValidationError(
+                    f"Version {version} not valid for profile {profile}"
+                )
         return cleaned_data
+
+    def get_versions(self, profile):
+        version_names = profile.geography_hierarchy.get_version_names
+        return Version.objects.filter(name__in=version_names)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.fields['profile'].required = True
+        profiles = self.fields["profile"].queryset
         if not self.instance.id:
-            profiles = self.fields["profile"].queryset
-
             user_group = get_user_group(self.current_user)
-
             filtered_profile = None
+            filtered_versions = None
+
             if profiles.count() == 1:
-                profile = profiles.first()
+                filtered_profile = profiles.first()
             elif user_group:
                 filtered_profile = profiles.filter(
                     name__iexact=user_group.name
                 ).first()
 
             if filtered_profile:
+                filtered_versions = self.get_versions(filtered_profile)
                 self.fields["profile"].initial = filtered_profile
+
+            if filtered_versions:
+                self.fields["version"].queryset = filtered_versions
+                if filtered_versions.count() == 1:
+                    self.fields["version"].initial = filtered_versions.first()
+            else:
+                self.fields["version"].queryset = Version.objects.none()
+        else:
+            profile = self.instance.profile
+            if self.data:
+                profile_id = self.data.get("profile", None)
+                if profile_id:
+                    profile = profiles.filter(id=profile_id).first()
+            if profile:
+                self.fields["version"].queryset = self.get_versions(profile)

--- a/wazimap_ng/datasets/models/geography.py
+++ b/wazimap_ng/datasets/models/geography.py
@@ -106,6 +106,14 @@ class GeographyHierarchy(BaseModel, SimpleHistory):
     def default_version(self):
         return self.configuration.get("default_version")
 
+    @property
+    def get_version_names(self):
+        versions = self.configuration.get("versions", [])
+        default_version = self.configuration.get("default_version", "")
+        if default_version and default_version not in versions:
+            versions.append(default_version)
+        return versions
+
     def help_text(self):
         return f"{self.name} : {self.description}"
 

--- a/wazimap_ng/datasets/serializers.py
+++ b/wazimap_ng/datasets/serializers.py
@@ -80,3 +80,8 @@ class MetaDataSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.MetaData
         fields = ('source', 'description', 'licence', 'url')
+
+class VersionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Version
+        fields = ("id", "name",)

--- a/wazimap_ng/general/static/js/dataset-admin.js
+++ b/wazimap_ng/general/static/js/dataset-admin.js
@@ -1,0 +1,41 @@
+(function ($) {
+    jQuery(document).ready(function ($) {
+        const $profileEl = $(document).find("#id_profile");
+        const $versionEl = $(document).find("#id_version");
+        const $emptyOptionEl = $("<option></option>");
+
+        $profileEl.on('change', function (e) {
+            // trigger "loadVersion" func only when it was manually changed
+            if (e.originalEvent !== undefined) {
+                // load loadVersion based on selected profile
+                loadVersion(e.target.value);
+            }
+        });
+
+        function appendOptionEl($outerEl, val, text){
+            $outerEl.append($emptyOptionEl.clone().attr("value", val).text(text));
+        }
+
+        function clearVersions() {
+            $versionEl.empty();
+            appendOptionEl($versionEl, "", "-----------")
+        }
+
+        function loadVersion(selectedProfile) {
+            if (selectedProfile) {
+                var url = `/api/v1/profiles/${selectedProfile}/versions/`;
+                $.ajax({
+                    url: url,
+                    success: function (data) {
+                        clearVersions();
+                        $.each(data, function (key, value) {
+                            appendOptionEl($versionEl, value.id, value.name)
+                        });
+                    }
+                })
+            } else {
+                clearVersions();
+            }
+        }
+    });
+})(django.jQuery);

--- a/wazimap_ng/profile/views.py
+++ b/wazimap_ng/profile/views.py
@@ -20,6 +20,7 @@ from . import serializers
 from ..cache import etag_profile_updated, last_modified_profile_updated
 
 from wazimap_ng.datasets.models import Geography, Version
+from wazimap_ng.datasets.serializers import VersionSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -119,4 +120,12 @@ def profile_geography_indicator_data(request, profile_id, geography_code, profil
 
     js = serializers.FullProfileIndicatorSerializer(instance=profile_indicator, geography=geography).data
 
+    return Response(js)
+
+@api_view()
+def profile_versions(request, profile_id):
+    profile = get_object_or_404(models.Profile, pk=profile_id)
+    version_names = profile.geography_hierarchy.get_version_names
+    versions = Version.objects.filter(name__in=version_names)
+    js = VersionSerializer(versions, many=True).data
     return Response(js)

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -73,6 +73,11 @@ urlpatterns = [
         name="profile-detail",
     ),
     path(
+        "api/v1/profiles/<int:profile_id>/versions/",
+        cache(profile_views.profile_versions),
+        name="profile-versions",
+    ),
+    path(
         "api/v1/profiles/<int:profile_id>/categories/",
         cache(profile_views.ProfileCategoriesList.as_view()),
         name="profile-categories",


### PR DESCRIPTION
## Description
Make sure the user can only select the valid version for the selected profile.

* Added js file to dataset admin so version dropdown changes when user change profile
* Added new url to give versions for a specific profile
* Added new view and serializer for the version to support js file 
* Updated code in dataset admin form to:
    * Update version queryset when a profile is changed or according to currently selected profile
    * Added validation so user can not select a version from any other profile's hierarchy


## Related Issue
https://wazimap.atlassian.net/browse/WNCM-269

## How to test it locally
**Initial form :**
Initial form is when you try to add a new object from the admin panel
Things to check:
* If there is only one profile:
     * profile should be selected by default
     * versions should be filtered according to the selected profile
     * if there is only one version select that version automatically
* If there are multiple profiles:
    * Profile is not selected but a user can only select a profile that exists in user groups
    * version field is empty on initial load
    * version field should be changed/populated if profile is changed
* When trying to save:
   * profile is required
   * version is required
   * If an error is thrown of version is required, version field data should be filtered according to selected profile
   * User not able to select any other version
   
**Change Form**

* Verison field is filtered according to the selected profile
* If profile field is changed version field should autoload
* if the user tries to save a profile with invalid version validations are thrown

Dataset admin: https://staging.wazimap-ng.openup.org.za/admin/datasets/dataset/

## Changelog
* Updated dataset admin form
* Updated geography hierarchy to add a new property get_version_names
* Added new view, url & serializer for versions according to profile
* Added js code to change versions when profile is changed in admin panel
* Added tests

### Added


### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
