### PR TITLE
Profile indicator UI changes

### DIFF
--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -47,7 +47,7 @@ class VariableFilterWidget(Widget):
 
     def get_context(self, name, value, attrs=None):
 
-        CHOICES = [('public', 'Public'), ('private', 'Private')]
+        CHOICES = [('public', 'All public variables'), ('private', 'Private variables of the selected profile')]
         choice_field = forms.fields.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
         queryset = self.choices.queryset.order_by(
             'dataset__profile__name',

--- a/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_indicator_admin.py
@@ -11,8 +11,10 @@ from wazimap_ng.general.admin.admin_base import BaseAdminModel, HistoryAdmin
 from wazimap_ng.general.admin import filters
 from django.db.models.functions import Concat
 
+
 class CategoryIndicatorFilter(filters.CategoryFilter):
     parameter_name = 'subcategory__category__id'
+
 
 @admin.register(models.ProfileIndicator)
 class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
@@ -24,9 +26,9 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
 
     exclude_common_list_display = True
     list_display = (
+        "label",
+        description("Variable", lambda x: x.indicator.name),
         "profile",
-        "label", 
-        description("Indicator", lambda x: x.indicator.name), 
         description("Category", lambda x: x.subcategory.category.name),
         "subcategory",
         "created",
@@ -35,17 +37,15 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
     )
 
     fieldsets = (
-        ("Database fields (can't change after being created)", {
-            'fields': ('profile', 'indicator', 'content_type')
-        }),
         ("Profile fields", {
-          'fields': ('label', 'subcategory', 'description', 'choropleth_method')
+            'fields': (
+            'profile', 'subcategory', 'label', 'indicator', 'content_type', 'choropleth_method', 'description')
         }),
         ("Charts", {
-          'fields': ('chart_configuration',)
+            'fields': ('chart_configuration',)
         })
     )
-    search_fields = ("label", )
+    search_fields = ("label",)
 
     form = ProfileIndicatorAdminForm
 
@@ -55,7 +55,7 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
         js = ("/static/js/profile-indicator-admin.js",)
 
     def get_readonly_fields(self, request, obj=None):
-        if obj: # editing an existing object
+        if obj:  # editing an existing object
             return ("profile",) + self.readonly_fields
         return self.readonly_fields
 
@@ -76,7 +76,7 @@ class ProfileIndicatorAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
             )
 
         elif not obj and request.method == "GET":
-             qs = qs = models.IndicatorSubcategory.objects.none()
+            qs = qs = models.IndicatorSubcategory.objects.none()
 
         form.base_fields["subcategory"].queryset = qs
 

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -106,13 +106,13 @@ class ProfileHighlight(BaseModel, SimpleHistory):
 
 
 class ProfileIndicator(BaseModel, SimpleHistory):
-    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE, help_text="The profile to which this profile indicator belongs")
     indicator = models.ForeignKey(
-        Indicator, on_delete=models.CASCADE, help_text="Indicator on which this indicator is based on.", verbose_name="variable"
+        Indicator, on_delete=models.CASCADE, verbose_name="variable"
     )
     subcategory = models.ForeignKey(IndicatorSubcategory, on_delete=models.CASCADE)
     label = models.CharField(max_length=255, null=False, blank=True, help_text="Label for the indicator displayed on the front-end")
-    description = HTMLField(blank=True)
+    description = HTMLField(blank=True, help_text="Use this to help your users interpret the indicator effectively")
     subindicators = JSONField(default=list, blank=True)
     choropleth_method = models.ForeignKey(ChoroplethMethod, null=False, on_delete=models.CASCADE)
     order = models.PositiveIntegerField(default=0, blank=False, null=False)

--- a/wazimap_ng/urls.py
+++ b/wazimap_ng/urls.py
@@ -167,6 +167,8 @@ urlpatterns = [
 
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
+admin.site.site_header = 'Wazimap Administration'
+
 if settings.DEBUG:
     import debug_toolbar
     urlpatterns = [


### PR DESCRIPTION
## Description

* The Public/Private toggle
    - Public becomes All public variables
    - “Private” becomes Private variables of the selected profile? 
* Place “Profile” field in “Profile fields” section
* Add “The profile to which this profile indicator belongs” as help text for the “Profile” field
* Lay out these fields as follows:
    - Profile - The profile to which this profile indicator belongs
    - Subcategory
    - Label
    - Variable - (remove help text)
    - Content type
    - Choropleth method
    - Description - Use this to help your users interpret the indicator effectively.
* Rearrange profile indicator list columns to:
    - Label (clickable)
    - Variable (not indicator)
    - Profile
    - Category
    - Subcategory
* Change admin title to “Wazimap Administration”

## Related Issue

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [ ]  🚀 is the code ready to be merged and go live?
- [ ]  🛠 does it work (build) locally

### Pull Request

- [ ]  📰 good title
- [ ]  📝good description
- [ ]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [ ]  commits are clean
- [ ]  commit messages are clean

### Code Quality

- [ ]  🚧 no commented out code
- [ ]  🖨 no unnecessary logging
- [ ]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
