### PR TITLE
Set QCluster recycle to 1

### DIFF
--- a/wazimap_ng/config/qcluster.py
+++ b/wazimap_ng/config/qcluster.py
@@ -16,5 +16,5 @@ class QCluster:
     Q_CLUSTER = {
         "redis": os.environ.get("REDIS_URL"),
         "workers": int(os.environ.get("Q_CLUSTER_WORKERS", 4)),
-        "recycle": int(os.environ.get("Q_CLUSTER_RECYCLE", 10)),
+        "recycle": int(os.environ.get("Q_CLUSTER_RECYCLE", 1)),
     }


### PR DESCRIPTION
## Description
Change Qcluster config to set recycle to 1
It will help in fixing out of memory issue

Before:
<img width="1055" alt="Screenshot 2022-03-16 at 1 10 47 PM" src="https://user-images.githubusercontent.com/6871866/158556754-9802774e-e69e-48b0-ab95-73bbda566200.png">

After:
<img width="1096" alt="Screenshot 2022-03-16 at 2 32 37 PM" src="https://user-images.githubusercontent.com/6871866/158556819-41f4c271-453a-4549-860d-17dec6762cfa.png">

So Basically in the first image q_cluster was taking up 900 MB of space and even after finishing up the task it didn't go down
In case of recycling of 1 we get the message : 
```
queue_1  | INFO 2022-03-16 08:58:54,231 recycled worker Process-1:7
queue_1  | INFO 2022-03-16 08:58:54,238 Process-1:11 ready for work at 28
```
Before even processed message comes in and out RAM goes down from 800 - 900 to approx 400
So we can clearly see the diff of recycle = 1 working as expected


## Related Issue
https://wazimap.atlassian.net/browse/WNCM-301

## How to test it locally
run docker-compose up and do `docker stats` to monitor activity for containers

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
