### PR TITLE
changing the selected variable option when profile or permission type is changed

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -143,7 +143,11 @@ def profile(geography_hierarchy):
         "urls": ["some_domain.com"]
     }
 
-    return ProfileFactory(geography_hierarchy=geography_hierarchy, configuration=configuration)
+    return ProfileFactory(
+        name="Profile",
+        geography_hierarchy=geography_hierarchy,
+        configuration=configuration
+    )
 
 @pytest.fixture
 def profile_group(profile):

--- a/tests/profile/admin/test_profile_indicator_admin.py
+++ b/tests/profile/admin/test_profile_indicator_admin.py
@@ -68,7 +68,7 @@ class TestProfileIndicatorAdmin:
         ]
 
     def test_subcategories_queryset_for_indicator(
-        self, mocked_request, profile_indicator, subcategory
+            self, mocked_request, profile_indicator, subcategory
     ):
         ma = ProfileIndicatorAdmin(ProfileIndicator, AdminSite())
         form = ma.get_form(mocked_request, profile_indicator)()
@@ -77,7 +77,7 @@ class TestProfileIndicatorAdmin:
         assert queryset.first() == subcategory
 
     def test_subcategories_empty_queryset_for_new_obj(
-        self, mocked_request, profile_indicator, subcategory
+            self, mocked_request, profile_indicator, subcategory
     ):
         ma = ProfileIndicatorAdmin(ProfileIndicator, AdminSite())
         form = ma.get_form(mocked_request)()
@@ -97,27 +97,27 @@ class TestProfileIndicatorAdmin:
         assert queryset.count() == 2
         # assert if quantative indicator in queryset
         assert (
-            queryset.filter(dataset__content_type="quantitative").first() == indicator
+                queryset.filter(dataset__content_type="quantitative").first() == indicator
         )
         # assert if qualitative indicator in queryset
         assert (
-            queryset.filter(dataset__content_type="qualitative").first()
-            == qualitative_indicator
+                queryset.filter(dataset__content_type="qualitative").first()
+                == qualitative_indicator
         )
 
 
 @pytest.mark.django_db
 class TestProfileIndicatorAdminChangeForm:
     def test_indicator_field_for_existing_object(
-        self,
-        client,
-        superuser,
-        profile_indicator,
-        profile,
-        indicator,
-        qualitative_indicator,
-        private_indicator_profile2,
-        public_indicator_profile2,
+            self,
+            client,
+            superuser,
+            profile_indicator,
+            profile,
+            indicator,
+            qualitative_indicator,
+            private_indicator_profile2,
+            public_indicator_profile2,
     ):
         """
         Test indicator field for existing profile indictaor
@@ -185,12 +185,12 @@ class TestProfileIndicatorAdminFormValidations:
         form = res.context["adminform"].form
         errors = form.errors
         assert (
-            errors["indicator"].data[0].message
-            == "Select a valid choice. That choice is not one of the available choices."
+                errors["indicator"].data[0].message
+                == "Select a valid choice. That choice is not one of the available choices."
         )
 
     def test_adding_private_indicator_from_different_profile(
-        self, client, superuser, profile, private_indicator_profile2
+            self, client, superuser, profile, private_indicator_profile2
     ):
         client.force_login(user=superuser)
         url = reverse("admin:profile_profileindicator_add")
@@ -207,6 +207,44 @@ class TestProfileIndicatorAdminFormValidations:
         form = res.context["adminform"].form
         errors = form.errors
         assert (
-            errors["__all__"].data[0].message
-            == "Private indicator private profile : private dataset -> private indicator is not valid for the selected profile"
+                errors["__all__"].data[0].message
+                == "Private indicator private profile : private dataset -> private indicator is not valid for the selected profile"
         )
+
+    def test_adding_private_indicator_of_the_selected_profile(
+            self, client, superuser, private_profile, private_indicator_profile2
+    ):
+        client.force_login(user=superuser)
+        url = reverse("admin:profile_profileindicator_add")
+        data = {
+            "metadata-TOTAL_FORMS": 0,
+            "metadata-INITIAL_FORMS": 0,
+            "chart_configuration": "{}",
+            "profile": private_profile.id,
+            "indicator": private_indicator_profile2.id,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context["adminform"].form
+        errors = form.errors
+        assert (('__all__' in errors) is False)
+
+    def test_adding_public_indicator_from_different_profile(
+            self, client, superuser, profile, public_indicator_profile2
+    ):
+        client.force_login(user=superuser)
+        url = reverse("admin:profile_profileindicator_add")
+        data = {
+            "metadata-TOTAL_FORMS": 0,
+            "metadata-INITIAL_FORMS": 0,
+            "chart_configuration": "{}",
+            "profile": profile.id,
+            "indicator": public_indicator_profile2.id,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context["adminform"].form
+        errors = form.errors
+        assert (('__all__' in errors) is False)

--- a/tests/profile/admin/test_profile_indicator_admin.py
+++ b/tests/profile/admin/test_profile_indicator_admin.py
@@ -1,35 +1,84 @@
 import pytest
 from django.contrib.admin.sites import AdminSite
+from django.urls import reverse
 
-from tests.profile.factories import ProfileIndicatorFactory, ProfileFactory, IndicatorCategoryFactory, \
-    IndicatorSubcategoryFactory
+from tests.profile.factories import (
+    ProfileIndicatorFactory,
+    ProfileFactory,
+    IndicatorCategoryFactory,
+    IndicatorSubcategoryFactory,
+)
 from tests.datasets.factories import DatasetFactory, IndicatorFactory
 from wazimap_ng.profile.models import ProfileIndicator, IndicatorSubcategory
+from wazimap_ng.datasets.models import Indicator
 from wazimap_ng.profile.admin.admins import ProfileIndicatorAdmin
+
+
+@pytest.fixture
+def private_dataset_profile1(profile, version):
+    return DatasetFactory(profile=profile, version=version, permission_type="private")
+
+
+@pytest.fixture
+def private_indicator_profile1(private_dataset):
+    return IndicatorFactory(name="private indicator", dataset=private_dataset)
+
+
+@pytest.fixture
+def private_dataset_profile2(private_profile):
+    return DatasetFactory(
+        profile=private_profile, name="private dataset", permission_type="private"
+    )
+
+
+@pytest.fixture
+def public_dataset_profile2(private_profile):
+    return DatasetFactory(profile=private_profile, permission_type="public")
+
+
+@pytest.fixture
+def private_indicator_profile2(private_dataset_profile2):
+    return IndicatorFactory(name="private indicator", dataset=private_dataset_profile2)
+
+
+@pytest.fixture
+def public_indicator_profile2(public_dataset_profile2):
+    return IndicatorFactory(name="private indicator", dataset=public_dataset_profile2)
 
 
 @pytest.mark.django_db
 class TestProfileIndicatorAdmin:
-
     def test_modeladmin_str(self):
         ma = ProfileIndicatorAdmin(ProfileIndicator, AdminSite())
-        assert str(ma) == 'profile.ProfileIndicatorAdmin'
+        assert str(ma) == "profile.ProfileIndicatorAdmin"
 
     def test_fieldset(self, mocked_request, profile_indicator):
         ma = ProfileIndicatorAdmin(ProfileIndicator, AdminSite())
         base_fields = list(ma.get_form(mocked_request, profile_indicator).base_fields)
 
-        assert base_fields == ['subcategory', 'label', 'indicator', 'content_type', 'choropleth_method', 'description',
-                               'chart_configuration', 'change_reason']
+        assert base_fields == [
+            "subcategory",
+            "label",
+            "indicator",
+            "content_type",
+            "choropleth_method",
+            "description",
+            "chart_configuration",
+            "change_reason",
+        ]
 
-    def test_subcategories_queryset_for_indicator(self, mocked_request, profile_indicator, subcategory):
+    def test_subcategories_queryset_for_indicator(
+        self, mocked_request, profile_indicator, subcategory
+    ):
         ma = ProfileIndicatorAdmin(ProfileIndicator, AdminSite())
         form = ma.get_form(mocked_request, profile_indicator)()
         queryset = form.fields["subcategory"].queryset
         assert queryset.count() == 1
         assert queryset.first() == subcategory
 
-    def test_subcategories_empty_queryset_for_new_obj(self, mocked_request, profile_indicator, subcategory):
+    def test_subcategories_empty_queryset_for_new_obj(
+        self, mocked_request, profile_indicator, subcategory
+    ):
         ma = ProfileIndicatorAdmin(ProfileIndicator, AdminSite())
         form = ma.get_form(mocked_request)()
         queryset = form.fields["subcategory"].queryset
@@ -47,6 +96,117 @@ class TestProfileIndicatorAdmin:
         # assert count
         assert queryset.count() == 2
         # assert if quantative indicator in queryset
-        assert queryset.filter(dataset__content_type="quantitative").first() == indicator
+        assert (
+            queryset.filter(dataset__content_type="quantitative").first() == indicator
+        )
         # assert if qualitative indicator in queryset
-        assert queryset.filter(dataset__content_type="qualitative").first() == qualitative_indicator
+        assert (
+            queryset.filter(dataset__content_type="qualitative").first()
+            == qualitative_indicator
+        )
+
+
+@pytest.mark.django_db
+class TestProfileIndicatorAdminChangeForm:
+    def test_indicator_field_for_existing_object(
+        self,
+        client,
+        superuser,
+        profile_indicator,
+        profile,
+        indicator,
+        qualitative_indicator,
+        private_indicator_profile2,
+        public_indicator_profile2,
+    ):
+        """
+        Test indicator field for existing profile indictaor
+        queryset should include all public variables and private
+        variables of current objects profile
+        """
+        client.force_login(user=superuser)
+        url = reverse(
+            "admin:profile_profileindicator_change", args=(profile_indicator.id,)
+        )
+        res = client.get(url, follow=True)
+        assert res.status_code == 200
+        form = res.context["adminform"].form
+
+        assert profile_indicator.profile == profile
+        queryset = form.fields["indicator"].queryset.order_by("id")
+        assert Indicator.objects.all().count() == 4
+        assert queryset.count() == 3
+        assert list(queryset) == [
+            indicator,
+            qualitative_indicator,
+            public_indicator_profile2,
+        ]
+
+
+@pytest.mark.django_db
+class TestProfileIndicatorAdminFormValidations:
+    def test_validation_for_required_fields(self, client, superuser):
+        client.force_login(user=superuser)
+        url = reverse("admin:profile_profileindicator_add")
+        data = {
+            "metadata-TOTAL_FORMS": 0,
+            "metadata-INITIAL_FORMS": 0,
+            "chart_configuration": "{}",
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context["adminform"].form
+        errors = form.errors
+        error_fields = [
+            "profile",
+            "subcategory",
+            "indicator",
+            "content_type",
+            "choropleth_method",
+        ]
+        assert list(errors.keys()) == error_fields
+
+        for field in error_fields:
+            assert errors[field].data[0].message == "This field is required."
+
+    def test_adding_non_existing_indicator(self, client, superuser):
+        client.force_login(user=superuser)
+        url = reverse("admin:profile_profileindicator_add")
+        data = {
+            "metadata-TOTAL_FORMS": 0,
+            "metadata-INITIAL_FORMS": 0,
+            "chart_configuration": "{}",
+            "indicator": 1000000,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context["adminform"].form
+        errors = form.errors
+        assert (
+            errors["indicator"].data[0].message
+            == "Select a valid choice. That choice is not one of the available choices."
+        )
+
+    def test_adding_private_indicator_from_different_profile(
+        self, client, superuser, profile, private_indicator_profile2
+    ):
+        client.force_login(user=superuser)
+        url = reverse("admin:profile_profileindicator_add")
+        data = {
+            "metadata-TOTAL_FORMS": 0,
+            "metadata-INITIAL_FORMS": 0,
+            "chart_configuration": "{}",
+            "profile": profile.id,
+            "indicator": private_indicator_profile2.id,
+        }
+        res = client.post(url, data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context["adminform"].form
+        errors = form.errors
+        assert (
+            errors["__all__"].data[0].message
+            == "Private indicator private profile : private dataset -> private indicator is not valid for the selected profile"
+        )

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -75,6 +75,8 @@
                     } else {
                         $(this).removeClass('hidden');
                     }
+                } else {
+                    $(this).prop('selected', true);
                 }
             })
         }

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -3,23 +3,12 @@
         const $profileEl = $(document).find("#id_profile");
         const $subcategoryEl = $(document).find("#id_subcategory");
         const $emptyOptionEl = $("<option></option>");
-        const $permissionOptionEl = $(document).find("#variable-permission-filter");
-        const permissionTypes = {public: 'public', private: 'private'};
-
-        filterVariables($profileEl.val(), $permissionOptionEl.find("input:checked").val());
 
         $profileEl.on('change', function (e) {
             // trigger "loadSubcategory" func only when it was manually changed
             if (e.originalEvent !== undefined) {
                 // load subcategories based on selected profile
                 loadSubcategory(e.target.value);
-                filterVariables(e.target.value, $permissionOptionEl.find("input:checked").val());
-            }
-        });
-
-        $permissionOptionEl.on('change', function (e) {
-            if (e.originalEvent !== undefined) {
-                filterVariables($profileEl.val(), e.target.value);
             }
         });
 
@@ -48,37 +37,6 @@
             } else {
                 clearSubcategories();
             }
-        }
-
-        function filterVariables(selectedProfile, selectedPermissionType) {
-            if (selectedProfile === '' && selectedPermissionType === permissionTypes.private) {
-                $('select#id_indicator').prop('disabled', true);
-            } else {
-                $('select#id_indicator').prop('disabled', false);
-            }
-
-            $('select#id_indicator option').each(function () {
-                if (this.value !== '') {
-                    //filter out the first option
-                    let optionPermissionType = $(this).attr('data-type');
-                    let optionProfile = $(this).attr('data-profileid');
-
-                    let isHidden = false;
-                    if (selectedPermissionType === permissionTypes.public && optionPermissionType !== permissionTypes.public) {
-                        isHidden = true;
-                    } else if (selectedPermissionType === permissionTypes.private && (optionProfile !== selectedProfile || optionPermissionType !== permissionTypes.private)) {
-                        isHidden = true;
-                    }
-
-                    if (isHidden) {
-                        $(this).addClass('hidden');
-                    } else {
-                        $(this).removeClass('hidden');
-                    }
-                } else {
-                    $(this).prop('selected', true);
-                }
-            })
         }
     });
 })(django.jQuery);

--- a/wazimap_ng/general/static/js/variable-filter-widget.js
+++ b/wazimap_ng/general/static/js/variable-filter-widget.js
@@ -1,16 +1,81 @@
-(function($) {
-    jQuery(document).ready(function($) {
+(function ($) {
+    jQuery(document).ready(function ($) {
         $(function () {
-            $("#variable-permission-filter input[type='radio']" ).on('change', ChangeVariableValues);
-        });
+            $("#variable-permission-filter input[type='radio']").on('change', ChangeVariableValues);
+            const $permissionOptionEl = $(document).find("#variable-permission-filter");
+            const permissionTypes = {public: 'public', private: 'private'};
+            const $profileEl = $(document).find("#id_profile");
 
-        function ChangeVariableValues() {
-            let permissionType = $(this).val();
-            let hiddenPermissionType = permissionType == "public" ? "private": "public";
-            let parent = $(this).parents("div");
-            parent.find("#id_indicator").find(`[data-type=${permissionType}]`).removeClass("hidden");
-            parent.find("#id_indicator").find(`[data-type=${hiddenPermissionType}]`).addClass("hidden");
-            parent.find("#id_indicator option[value='']").attr('selected', true);
-        }
+            filterVariables(getProfileId($profileEl), $permissionOptionEl.find("input:checked").val(), false);
+
+            $profileEl.on('change', function (e) {
+                // trigger "loadSubcategory" func only when it was manually changed
+                if (e.originalEvent !== undefined) {
+                    // load subcategories based on selected profile
+                    filterVariables(getProfileId($profileEl), $permissionOptionEl.find("input:checked").val(), true);
+                }
+            });
+
+            $permissionOptionEl.on('change', function (e) {
+                if (e.originalEvent !== undefined) {
+                    filterVariables(getProfileId($profileEl), e.target.value, true);
+                }
+            });
+
+            function ChangeVariableValues() {
+                let permissionType = $(this).val();
+                let hiddenPermissionType = permissionType == "public" ? "private" : "public";
+                let parent = $(this).parents("div");
+                parent.find("#id_indicator").find(`[data-type=${permissionType}]`).removeClass("hidden");
+                parent.find("#id_indicator").find(`[data-type=${hiddenPermissionType}]`).addClass("hidden");
+                parent.find("#id_indicator option[value='']").attr('selected', true);
+            }
+
+            function getProfileId($profileEl) {
+                let profileId;
+                if ($profileEl.length > 0) {
+                    profileId = $profileEl.val();
+                } else {
+                    profileId = $('input[name=selected_profile_id]').val();
+                }
+
+                return profileId;
+            }
+
+            function filterVariables(selectedProfile, selectedPermissionType, changeSelectedOption) {
+                console.log({selectedProfile, selectedPermissionType})
+                if (selectedProfile === '' && selectedPermissionType === permissionTypes.private) {
+                    $('select#id_indicator').prop('disabled', true);
+                } else {
+                    $('select#id_indicator').prop('disabled', false);
+                }
+
+                $('select#id_indicator option').each(function () {
+                    if (this.value !== '') {
+                        //filter out the first option
+                        let optionPermissionType = $(this).attr('data-type');
+                        let optionProfile = $(this).attr('data-profileid');
+
+                        let isHidden = false;
+                        if (selectedPermissionType === permissionTypes.public && optionPermissionType !== permissionTypes.public) {
+                            isHidden = true;
+                        } else if (selectedPermissionType === permissionTypes.private && (optionProfile !== selectedProfile || optionPermissionType !== permissionTypes.private)) {
+                            isHidden = true;
+                        }
+
+                        if (isHidden) {
+                            $(this).addClass('hidden');
+                        } else {
+                            $(this).removeClass('hidden');
+                        }
+                    } else {
+                        if (changeSelectedOption) {
+                            //do not change the selected option on page load
+                            $(this).prop('selected', true);
+                        }
+                    }
+                })
+            }
+        });
     });
 })(django.jQuery);

--- a/wazimap_ng/general/static/js/variable-filter-widget.js
+++ b/wazimap_ng/general/static/js/variable-filter-widget.js
@@ -35,15 +35,12 @@
                 let profileId;
                 if ($profileEl.length > 0) {
                     profileId = $profileEl.val();
-                } else {
-                    profileId = $('input[name=selected_profile_id]').val();
                 }
 
                 return profileId;
             }
 
             function filterVariables(selectedProfile, selectedPermissionType, changeSelectedOption) {
-                console.log({selectedProfile, selectedPermissionType})
                 if (selectedProfile === '' && selectedPermissionType === permissionTypes.private) {
                     $('select#id_indicator').prop('disabled', true);
                 } else {
@@ -57,9 +54,9 @@
                         let optionProfile = $(this).attr('data-profileid');
 
                         let isHidden = false;
-                        if (selectedPermissionType === permissionTypes.public && optionPermissionType !== permissionTypes.public) {
+                        if (selectedProfile !== undefined && selectedPermissionType === permissionTypes.private && optionProfile !== selectedProfile) {
                             isHidden = true;
-                        } else if (selectedPermissionType === permissionTypes.private && (optionProfile !== selectedProfile || optionPermissionType !== permissionTypes.private)) {
+                        } else if (optionPermissionType !== selectedPermissionType) {
                             isHidden = true;
                         }
 

--- a/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
+++ b/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
@@ -1,7 +1,12 @@
 <div id="variable-permission-filter">
     {{ choice_field }}
 </div>
-<select id="id_indicator" required name="{{ name }}">
+<input type="hidden" name="selected_profile_id" value="{{ profile_id }}">
+<select
+        id="id_indicator"
+        required
+        name="{{ name }}"
+>
     <option value=''>-------------</option>
     {% for choice in choices %}
         <option

--- a/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
+++ b/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
@@ -1,7 +1,6 @@
 <div id="variable-permission-filter">
     {{ choice_field }}
 </div>
-<input type="hidden" name="selected_profile_id" value="{{ profile_id }}">
 <select
         id="id_indicator"
         required

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -6,6 +6,7 @@ from guardian.shortcuts import (
     get_group_perms, get_perms_for_model, get_groups_with_perms
 )
 from django import forms
+from django.db.models import Q
 
 from wazimap_ng.general.services import permissions
 from wazimap_ng.datasets.models import Indicator
@@ -68,15 +69,17 @@ class VariableFilterWidget(Widget):
             value = queryset.get(id=value)
             selected_permission = value.dataset.permission_type
 
-        profile_id = None
         if self.instance is not None:
             profile_id = self.instance.profile_id
+            if profile_id is not None:
+                queryset = queryset.filter(
+                    Q(dataset__permission_type="public") | Q(dataset__permission_type="private",
+                                                             dataset__profile_id=profile_id))
 
         return {
             'name': name,
             'value': value,
             'choices': queryset,
             'permission_type': selected_permission,
-            "choice_field": choice_field.widget.render(f"{name}_variable_type", selected_permission),
-            "profile_id": profile_id
+            "choice_field": choice_field.widget.render(f"{name}_variable_type", selected_permission)
         }

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -8,6 +8,7 @@ from guardian.shortcuts import (
 from django import forms
 
 from wazimap_ng.general.services import permissions
+from wazimap_ng.datasets.models import Indicator
 
 
 def customTitledFilter(title):
@@ -49,11 +50,14 @@ class VariableFilterWidget(Widget):
         css = {'all': ("/static/css/variable-filter-widget.css",)}
         js = ("/static/js/variable-filter-widget.js",)
 
-    def get_context(self, name, value, attrs=None):
+    def __init__(self, attrs=None, instance=None):
+        self.instance = instance
+        super().__init__(attrs=attrs)
+
+    def get_context(self, name, value, attrs=None, instance=None):
         CHOICES = [('public', 'All public variables'), ('private', 'Private variables of the selected profile')]
         choice_field = forms.fields.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
-
-        queryset = self.choices.queryset.order_by(
+        queryset = Indicator.objects.all().order_by(
             'dataset__profile__name',
             'dataset__name',
             'name'
@@ -68,5 +72,6 @@ class VariableFilterWidget(Widget):
             'value': value,
             'choices': queryset,
             'permission_type': selected_permission,
-            "choice_field": choice_field.widget.render(f"{name}_variable_type", selected_permission)
+            "choice_field": choice_field.widget.render(f"{name}_variable_type", selected_permission),
+            "profile_id": self.instance.profile_id
         }

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -51,15 +51,11 @@ class VariableFilterWidget(Widget):
         css = {'all': ("/static/css/variable-filter-widget.css",)}
         js = ("/static/js/variable-filter-widget.js",)
 
-    def __init__(self, attrs=None, instance=None):
-        self.instance = instance
-        super().__init__(attrs=attrs)
-
-    def get_context(self, name, value, attrs=None, instance=None):
+    def get_context(self, name, value, attrs=None):
         CHOICES = [('public', 'All public variables'), ('private', 'Private variables of the selected profile')]
 
         choice_field = forms.fields.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
-        queryset = Indicator.objects.all().order_by(
+        queryset = self.choices.queryset.order_by(
             'dataset__profile__name',
             'dataset__name',
             'name'
@@ -68,13 +64,6 @@ class VariableFilterWidget(Widget):
         if value:
             value = queryset.get(id=value)
             selected_permission = value.dataset.permission_type
-
-        if self.instance is not None:
-            profile_id = self.instance.profile_id
-            if profile_id is not None:
-                queryset = queryset.filter(
-                    Q(dataset__permission_type="public") | Q(dataset__permission_type="private",
-                                                             dataset__profile_id=profile_id))
 
         return {
             'name': name,

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -61,8 +61,8 @@ class VariableFilterWidget(Widget):
             'name'
         )
         selected_permission = "public"
+        value = queryset.filter(id=value).first()
         if value:
-            value = queryset.get(id=value)
             selected_permission = value.dataset.permission_type
 
         return {

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -56,6 +56,7 @@ class VariableFilterWidget(Widget):
 
     def get_context(self, name, value, attrs=None, instance=None):
         CHOICES = [('public', 'All public variables'), ('private', 'Private variables of the selected profile')]
+
         choice_field = forms.fields.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
         queryset = Indicator.objects.all().order_by(
             'dataset__profile__name',
@@ -67,11 +68,15 @@ class VariableFilterWidget(Widget):
             value = queryset.get(id=value)
             selected_permission = value.dataset.permission_type
 
+        profile_id = None
+        if self.instance is not None:
+            profile_id = self.instance.profile_id
+
         return {
             'name': name,
             'value': value,
             'choices': queryset,
             'permission_type': selected_permission,
             "choice_field": choice_field.widget.render(f"{name}_variable_type", selected_permission),
-            "profile_id": self.instance.profile_id
+            "profile_id": profile_id
         }

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -61,9 +61,12 @@ class VariableFilterWidget(Widget):
             'name'
         )
         selected_permission = "public"
-        value = queryset.filter(id=value).first()
-        if value:
-            selected_permission = value.dataset.permission_type
+
+        try:
+            value = queryset.get(id=value)
+            selected_permission = value and value.dataset.permission_type
+        except:
+            pass
 
         return {
             'name': name,

--- a/wazimap_ng/profile/admin/forms/profile_highlight_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_highlight_form.py
@@ -6,6 +6,7 @@ from ... import models
 from wazimap_ng.datasets.models import Indicator
 from wazimap_ng.general.widgets import VariableFilterWidget
 from wazimap_ng.general.admin.forms import HistoryAdminForm
+from wazimap_ng.profile.admin.utils import filter_indicators_by_profile
 
 logger = logging.getLogger(__name__)
 
@@ -27,13 +28,16 @@ class ProfileHighlightForm(HistoryAdminForm):
         super().__init__(*args, **kwargs)
         is_saving_new_item = "indicator" in self.data
         is_editing_item = self.instance.pk is not None
-        self.fields['indicator'].queryset = Indicator.objects.filter(
+        queryset = Indicator.objects.filter(
             dataset__content_type="quantitative"
         )
 
-        self.fields['indicator'].widget = VariableFilterWidget(
-            instance=self.instance
-        )
+        if self.instance:
+            queryset = filter_indicators_by_profile(
+                self.instance.profile_id, queryset
+            )
+
+        self.fields['indicator'].queryset = queryset
 
         try:
             if is_saving_new_item:

--- a/wazimap_ng/profile/admin/forms/profile_highlight_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_highlight_form.py
@@ -31,6 +31,10 @@ class ProfileHighlightForm(HistoryAdminForm):
             dataset__content_type="quantitative"
         )
 
+        self.fields['indicator'].widget = VariableFilterWidget(
+            instance=self.instance
+        )
+
         try:
             if is_saving_new_item:
                 variable_id = int(self.data.get('indicator'))

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -5,11 +5,13 @@ from wazimap_ng.general.widgets import VariableFilterWidget
 from wazimap_ng.general.admin.forms import HistoryAdminForm
 from django_json_widget.widgets import JSONEditorWidget
 
+
 from ... import models
 from wazimap_ng.datasets.models import Indicator
 from wazimap_ng.config.common import (
     DENOMINATOR_CHOICES, PERMISSION_TYPES, PI_CONTENT_TYPE
 )
+from wazimap_ng.profile.admin.utils import filter_indicators_by_profile
 
 
 class ProfileIndicatorAdminForm(HistoryAdminForm):
@@ -18,24 +20,31 @@ class ProfileIndicatorAdminForm(HistoryAdminForm):
         fields = '__all__'
         widgets = {
             'chart_configuration': JSONEditorWidget,
+            'indicator': VariableFilterWidget
         }
 
     def clean(self):
         cleaned_data = super(ProfileIndicatorAdminForm, self).clean()
+        if "indicator" not in cleaned_data:
+            raise forms.ValidationError(
+                f"Invalid value selected for variable."
+            )
+
         indicator = cleaned_data.get('indicator', None)
+        profile = cleaned_data.get('profile', None)
 
+        if not profile and self.instance:
+            profile = self.instance.profile
+    
         permission_type = indicator.dataset.permission_type
-        current_profile_id = self.instance.profile_id
-        indicator_profile_id = indicator.dataset.profile_id
-
-        if permission_type == "private" and current_profile_id != indicator_profile_id:
+        if permission_type == "private" and profile != indicator.dataset.profile:
             raise forms.ValidationError(
                 f"Private indicator {indicator} is not valid for the selected profile"
             )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.fields['indicator'].required = True
         if self.instance:
-            self.fields['indicator'].widget = VariableFilterWidget(
-                instance=self.instance
-            )
+            profile_id = self.instance.profile_id
+            self.fields['indicator'].queryset = filter_indicators_by_profile(profile_id)

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -28,14 +28,15 @@ class ProfileIndicatorAdminForm(HistoryAdminForm):
         indicator = cleaned_data.get('indicator', None)
         profile = cleaned_data.get('profile', None)
 
-        if not profile and self.instance:
+        if not profile and self.instance.id:
             profile = self.instance.profile
-    
-        permission_type = indicator.dataset.permission_type
-        if permission_type == "private" and profile != indicator.dataset.profile:
-            raise forms.ValidationError(
-                f"Private indicator {indicator} is not valid for the selected profile"
-            )
+
+        if indicator:
+            permission_type = indicator.dataset.permission_type
+            if permission_type == "private" and profile != indicator.dataset.profile:
+                raise forms.ValidationError(
+                    f"Private indicator {indicator} is not valid for the selected profile"
+                )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -25,11 +25,6 @@ class ProfileIndicatorAdminForm(HistoryAdminForm):
 
     def clean(self):
         cleaned_data = super(ProfileIndicatorAdminForm, self).clean()
-        if "indicator" not in cleaned_data:
-            raise forms.ValidationError(
-                f"Invalid value selected for variable."
-            )
-
         indicator = cleaned_data.get('indicator', None)
         profile = cleaned_data.get('profile', None)
 

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -18,6 +18,12 @@ class ProfileIndicatorAdminForm(HistoryAdminForm):
         model = models.ProfileIndicator
         fields = '__all__'
         widgets = {
-            'indicator': VariableFilterWidget,
             'chart_configuration': JSONEditorWidget,
         }
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.instance:
+            self.fields['indicator'].widget = VariableFilterWidget(
+                instance=self.instance
+            )

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -13,13 +13,25 @@ from wazimap_ng.config.common import (
 
 
 class ProfileIndicatorAdminForm(HistoryAdminForm):
-
     class Meta:
         model = models.ProfileIndicator
         fields = '__all__'
         widgets = {
             'chart_configuration': JSONEditorWidget,
         }
+
+    def clean(self):
+        cleaned_data = super(ProfileIndicatorAdminForm, self).clean()
+        indicator = cleaned_data.get('indicator', None)
+
+        permission_type = indicator.dataset.permission_type
+        current_profile_id = self.instance.profile_id
+        indicator_profile_id = indicator.dataset.profile_id
+
+        if permission_type == "private" and current_profile_id != indicator_profile_id:
+            raise forms.ValidationError(
+                f"Private indicator {indicator} is not valid for the selected profile"
+            )
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)

--- a/wazimap_ng/profile/admin/forms/profile_key_metrics.py
+++ b/wazimap_ng/profile/admin/forms/profile_key_metrics.py
@@ -20,7 +20,6 @@ class ProfileKeyMetricsForm(HistoryAdminForm):
         model = models.ProfileKeyMetrics
         fields = "__all__"
         widgets = {
-            'variable': VariableFilterWidget
         }
 
     def __init__(self, *args, **kwargs):
@@ -31,6 +30,11 @@ class ProfileKeyMetricsForm(HistoryAdminForm):
         self.fields['variable'].queryset = Indicator.objects.filter(
             dataset__content_type="quantitative"
         )
+        
+        if self.instance:
+            self.fields['variable'].widget = VariableFilterWidget(
+                instance=self.instance
+            )
 
         try:
             if is_saving_new_item:

--- a/wazimap_ng/profile/admin/forms/profile_key_metrics.py
+++ b/wazimap_ng/profile/admin/forms/profile_key_metrics.py
@@ -20,6 +20,7 @@ class ProfileKeyMetricsForm(HistoryAdminForm):
         model = models.ProfileKeyMetrics
         fields = "__all__"
         widgets = {
+            "variable": VariableFilterWidget
         }
 
     def __init__(self, *args, **kwargs):
@@ -30,11 +31,6 @@ class ProfileKeyMetricsForm(HistoryAdminForm):
         self.fields['variable'].queryset = Indicator.objects.filter(
             dataset__content_type="quantitative"
         )
-        
-        if self.instance:
-            self.fields['variable'].widget = VariableFilterWidget(
-                instance=self.instance
-            )
 
         try:
             if is_saving_new_item:

--- a/wazimap_ng/profile/admin/utils.py
+++ b/wazimap_ng/profile/admin/utils.py
@@ -1,0 +1,13 @@
+from django.db.models import Q
+from wazimap_ng.datasets.models import Indicator
+
+
+def filter_indicators_by_profile(profile_id, queryset=None):
+    if not queryset:
+        queryset = Indicator.objects.all()
+    if profile_id:
+        queryset = queryset.filter(
+            Q(dataset__permission_type="public")
+            | Q(dataset__permission_type="private", dataset__profile_id=profile_id)
+        )
+    return queryset


### PR DESCRIPTION
## Description
changing the selected variable when profile or permission type is changed while adding/modifying profile indicators

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-325

## How to test it locally
* go to add indicator page
* select a variable
* change the selected profile / permission type
* confirm that the selected variable is `---------`

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [ ]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
