### PR TITLE
Fix out of memory issue for indicator data task execution

### DIFF
--- a/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
+++ b/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
@@ -18,7 +18,7 @@ from wazimap_ng.datasets.tasks.indicator_data_extraction import (
 class TestIndicatorDataExtraction:
     def test_basic_extraction(self, indicator, geography, indicatordata_json):
 
-        indicator_data_items = indicator_data_extraction(indicator)
+        indicator_data_extraction(indicator)
 
         indicator_data = IndicatorData.objects.get(geography=geography)
 
@@ -28,9 +28,7 @@ class TestIndicatorDataExtraction:
         def no_data(x): return len(x.data) == 0
 
         assert IndicatorData.objects.count() == 0
-
-        indicator_data_items = indicator_data_extraction(indicator)
-        assert len(indicator_data_items) == 1
+        indicator_data_extraction(indicator)
         assert IndicatorData.objects.count() == 1
 
         assert all(no_data(idata) for idata in IndicatorData.objects.exclude(geography=geography))
@@ -40,21 +38,18 @@ class TestIndicatorDataExtraction:
 
         assert IndicatorData.objects.count() == 0
 
-        indicator_data_items = indicator_data_extraction(indicator)
-        assert len(indicator_data_items) == 1
+        indicator_data_extraction(indicator)
         assert IndicatorData.objects.count() == 1
 
-        indicator_data_items = indicator_data_extraction(indicator)
-        assert len(indicator_data_items) == 1
+        indicator_data_extraction(indicator)
         assert IndicatorData.objects.count() == 1
 
     @pytest.mark.usefixtures("child_datasetdata")
     @pytest.mark.usefixtures("child_geographies")
     def test_three_geographies(self, indicator, geography):
-        indicator_data_items = indicator_data_extraction(indicator)
+        indicator_data_extraction(indicator)
         num_geographies = 1 + geography.get_children().count()
         assert IndicatorData.objects.count() == num_geographies
-        assert len(indicator_data_items) == num_geographies
 
         new_geographies = geography.get_children()
 

--- a/wazimap_ng/datasets/tasks/indicator_data_extraction.py
+++ b/wazimap_ng/datasets/tasks/indicator_data_extraction.py
@@ -7,27 +7,24 @@ from .. import models
 
 logger = logging.getLogger(__name__)
 
+
 @transaction.atomic
 def indicator_data_extraction(indicator, *args, universe=None, **kwargs):
 
     indicator.indicatordata_set.all().delete()
-
-    data_rows = []
-    datasetdata_qs = models.DatasetData.objects.filter(dataset=indicator.dataset).order_by("geography", "id")
-
+    datasetdata_qs = (
+        models.DatasetData.objects.filter(dataset=indicator.dataset)
+        .order_by("geography", "id")
+        .values("geography_id", "data")
+    )
     if universe is not None:
         datasetdata_qs = datasetdata_qs.filter(**universe)
 
-    grouped_datasetdata = groupby(datasetdata_qs, lambda dd: dd.geography)
+    grouped_datasetdata = groupby(datasetdata_qs, lambda dd: dd["geography_id"])
 
     for g, geography_data in grouped_datasetdata:
-        indicator_data = models.IndicatorData(indicator=indicator, geography=g)
-        indicator_data.data = [
-            dd.data for dd in geography_data
-        ]
-
-        data_rows.append(indicator_data)
-
-    objs = models.IndicatorData.objects.bulk_create(data_rows, 1000)
-
-    return objs
+        models.IndicatorData.objects.create(
+            indicator=indicator,
+            geography_id=g,
+            data=[dd["data"] for dd in geography_data],
+        )


### PR DESCRIPTION
## Description
Fix issue of the server running out of memory while executing an indicator data extraction task

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-265

## How to test it locally
* Create a variable and check RAM usage for task execution
* Switch branch to this fix
*  Create variable with same group & dataset and observe RAM usage
* RAM usage and task execution time should be reduced

To check memory consumption use: `docker stats` or `htop`

## Changelog

Updated inidicator data task to use values to get specific data
removed use of bulk_create
formatted using black

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
