### PR TITLE
Fix out of memory issue for indicator data task execution

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,12 @@ jobs:
       - run: docker-compose run --rm web python manage.py collectstatic --no-input
       - name: Run tests
         run: docker-compose run --rm -e DJANGO_CONFIGURATION=Test web pytest /app/tests
+      - name: Run instance monitoring
+        run: docker-compose run --rm web df -h
       - name: Run selenium tests
         run: docker-compose run --rm -e DJANGO_CONFIGURATION=Test web python3 manage.py test test_selenium
+      - name: Run instance monitoring
+        run: docker-compose run --rm web df -h
 
         # Dev environment smoke test
       - name: Migrate schema

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - DJANGO_CONFIGURATION
 
   selenium:
-    image: selenium/standalone-chrome
+    image: selenium/standalone-chrome:98.0.4758.102
     ports:
       - "4444:4444"
       - "5900:5900"

--- a/test_selenium/datasets/admin/test_dataset_admin.py
+++ b/test_selenium/datasets/admin/test_dataset_admin.py
@@ -23,11 +23,12 @@ class TestProfileVerisons(BaseTestCase):
         )
         assert profile_field.get_attribute("required") == "true"
         profile_field = Select(profile_field)
-        assert len(profile_field.options) == 3
+        assert len(profile_field.options) == 4
         profile_options = profile_field.options
         assert profile_options[0].text == "---------"
         assert profile_options[1].text == "private_profile"
         assert profile_options[2].text == "public_profile"
+        assert profile_options[3].text == "public_profile2"
 
         version_field = WebDriverWait(self.selenium, 2).until(
             EC.element_to_be_clickable((By.ID, "id_version"))
@@ -73,11 +74,12 @@ class TestProfileVerisons(BaseTestCase):
         )
         assert profile_field.get_attribute("required") == "true"
         profile_field = Select(profile_field)
-        assert len(profile_field.options) == 3
+        assert len(profile_field.options) == 4
         profile_options = profile_field.options
         assert profile_options[0].text == "---------"
         assert profile_options[1].text == "private_profile"
         assert profile_options[2].text == "public_profile"
+        assert profile_options[3].text == "public_profile2"
 
         self.selenium.execute_script(
             "arguments[0].setAttribute('value','100000')", profile_options[1]

--- a/test_selenium/profile/admin/test_profile_indicator_admin.py
+++ b/test_selenium/profile/admin/test_profile_indicator_admin.py
@@ -1,0 +1,61 @@
+from test_selenium.test_base import BaseTestCase
+
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.select import Select
+
+from django.urls import reverse
+
+
+class TestProfileIndicatorAdmin(BaseTestCase):
+    def test_if_private_variables_are_filtered_correctly(self):
+        self.login_into_adminpanel()
+        add_profile_indicator_url = self.get_url(reverse("admin:profile_profileindicator_add"))
+        self.selenium.get(add_profile_indicator_url)
+
+        main_div = self.get_element("content")
+
+        # no profile is selected, permission type is private. variable select should be disabled
+        self.set_permission_type('private')
+        assert main_div.find_element(by=By.CSS_SELECTOR, value="select#id_indicator").get_attribute(
+            "disabled") == "true"
+
+        # profile 1, public
+        self.select_profile('public_profile')
+        self.set_permission_type('public')
+
+        self.assert_variable_options(
+            ["-------------", "public_profile : dataset1 -> indicator1", "public_profile2 : dataset3 -> indicator3"])
+
+        # profile 2
+        self.select_profile('public_profile2')
+        self.set_permission_type('private')
+
+        self.assert_variable_options(
+            ["-------------", "public_profile2 : dataset4 -> indicator4"])
+
+    def select_profile(self, profile):
+        profile_field = WebDriverWait(self.selenium, 2).until(
+            EC.element_to_be_clickable((By.ID, "id_profile"))
+        )
+        profile_field = Select(profile_field)
+
+        profile_field.select_by_visible_text(profile)
+
+    def set_permission_type(self, type):
+        main_div = self.get_element("content")
+        main_div.find_element(by=By.CSS_SELECTOR, value="#variable-permission-filter input[value=" + type + "]").click()
+
+    def assert_variable_options(self, options):
+        main_div = self.get_element("content")
+
+        main_div.find_element(by=By.CSS_SELECTOR, value="select#id_indicator").click()
+
+        ele = main_div.find_elements(by=By.CSS_SELECTOR, value="select#id_indicator option:not([class^='hidden'])")
+        assert len(ele) == len(options)
+
+        index = 0
+        for option in options:
+            assert ele[index].text == option
+            index += 1

--- a/test_selenium/test_base.py
+++ b/test_selenium/test_base.py
@@ -38,6 +38,10 @@ class BaseTestCase(LiveServerTestCase):
         # Set host to externally accessible web server address
         cls.host = socket.gethostbyname(socket.gethostname())
 
+        chrome_options = webdriver.ChromeOptions()
+        chrome_options.add_argument('no-sandbox')
+        chrome_options.add_argument('disable-dev-shm-usage')
+
         # Instantiate the remote WebDriver
         cls.selenium = webdriver.Remote(
             #  Set to: htttp://{selenium-container-name}:port/wd/hub
@@ -46,7 +50,10 @@ class BaseTestCase(LiveServerTestCase):
             command_executor="http://selenium:4444/wd/hub",
             # Set to CHROME since we are using the Chrome container
             desired_capabilities=DesiredCapabilities.CHROME,
+            options=chrome_options
         )
+
+        print(cls.selenium.capabilities)
 
     def setUp(self):
         self.site_header_text = "Wazimap Administration"

--- a/test_selenium/test_base.py
+++ b/test_selenium/test_base.py
@@ -20,6 +20,8 @@ from tests.profile.factories import ProfileFactory
 from tests.datasets.factories import (
     GeographyHierarchyFactory,
     VersionFactory,
+    DatasetFactory,
+    IndicatorFactory,
 )
 
 
@@ -66,8 +68,17 @@ class BaseTestCase(LiveServerTestCase):
                 "versions": [self.version1.name, self.version2.name],
             }
         )
+        self.public_profile_hierarchy2 = GeographyHierarchyFactory(
+            configuration={
+                "default_version": self.version2.name,
+                "versions": [self.version2.name, self.version3.name],
+            }
+        )
         self.public_profile = ProfileFactory(
             name="public_profile", geography_hierarchy=self.public_profile_hierarchy
+        )
+        self.public_profile2 = ProfileFactory(
+            name="public_profile2", geography_hierarchy=self.public_profile_hierarchy2
         )
 
         self.private_profile_hierarchy = GeographyHierarchyFactory(
@@ -81,6 +92,18 @@ class BaseTestCase(LiveServerTestCase):
             permission_type="private",
             geography_hierarchy=self.private_profile_hierarchy,
         )
+
+        self.dataset1 = DatasetFactory(name="dataset1", profile=self.public_profile, permission_type="public")
+        self.indicator1 = IndicatorFactory(name="indicator1", dataset=self.dataset1)
+
+        self.dataset2 = DatasetFactory(name="dataset2", profile=self.public_profile, permission_type="private")
+        self.indicator2 = IndicatorFactory(name="indicator2", dataset=self.dataset2)
+
+        self.dataset3 = DatasetFactory(name="dataset3", profile=self.public_profile2, permission_type="public")
+        self.indicator3 = IndicatorFactory(name="indicator3", dataset=self.dataset3)
+
+        self.dataset4 = DatasetFactory(name="dataset4", profile=self.public_profile2, permission_type="private")
+        self.indicator4 = IndicatorFactory(name="indicator4", dataset=self.dataset4)
 
         # Create superuser
         self.user_password = "mypassword"

--- a/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
+++ b/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
@@ -18,7 +18,7 @@ from wazimap_ng.datasets.tasks.indicator_data_extraction import (
 class TestIndicatorDataExtraction:
     def test_basic_extraction(self, indicator, geography, indicatordata_json):
 
-        indicator_data_items = indicator_data_extraction(indicator)
+        indicator_data_extraction(indicator)
 
         indicator_data = IndicatorData.objects.get(geography=geography)
 
@@ -28,9 +28,7 @@ class TestIndicatorDataExtraction:
         def no_data(x): return len(x.data) == 0
 
         assert IndicatorData.objects.count() == 0
-
-        indicator_data_items = indicator_data_extraction(indicator)
-        assert len(indicator_data_items) == 1
+        indicator_data_extraction(indicator)
         assert IndicatorData.objects.count() == 1
 
         assert all(no_data(idata) for idata in IndicatorData.objects.exclude(geography=geography))
@@ -40,21 +38,18 @@ class TestIndicatorDataExtraction:
 
         assert IndicatorData.objects.count() == 0
 
-        indicator_data_items = indicator_data_extraction(indicator)
-        assert len(indicator_data_items) == 1
+        indicator_data_extraction(indicator)
         assert IndicatorData.objects.count() == 1
 
-        indicator_data_items = indicator_data_extraction(indicator)
-        assert len(indicator_data_items) == 1
+        indicator_data_extraction(indicator)
         assert IndicatorData.objects.count() == 1
 
     @pytest.mark.usefixtures("child_datasetdata")
     @pytest.mark.usefixtures("child_geographies")
     def test_three_geographies(self, indicator, geography):
-        indicator_data_items = indicator_data_extraction(indicator)
+        indicator_data_extraction(indicator)
         num_geographies = 1 + geography.get_children().count()
         assert IndicatorData.objects.count() == num_geographies
-        assert len(indicator_data_items) == num_geographies
 
         new_geographies = geography.get_children()
 

--- a/wazimap_ng/config/test.py
+++ b/wazimap_ng/config/test.py
@@ -14,9 +14,9 @@ class Test(Common):
     NOSE_ARGS = [
         BASE_DIR,
         '-s',
-        '--nologcapture',
+        # '--nologcapture',
         # '--with-coverage',
-        '--with-progressive',
+        # '--with-progressive',
         '--cover-package=wazimap_ng',
         '--cover-html'
     ]

--- a/wazimap_ng/datasets/tasks/indicator_data_extraction.py
+++ b/wazimap_ng/datasets/tasks/indicator_data_extraction.py
@@ -26,6 +26,7 @@ def indicator_data_extraction(indicator, *args, universe={}, **kwargs):
                 models.DatasetData.objects.filter(
                     dataset=indicator.dataset, geography_id=g
                 )
+                .filter(**universe)
                 .order_by("id")
                 .values_list("data", flat=True)
             ),

--- a/wazimap_ng/general/static/js/profile-indicator-admin.js
+++ b/wazimap_ng/general/static/js/profile-indicator-admin.js
@@ -3,16 +3,27 @@
         const $profileEl = $(document).find("#id_profile");
         const $subcategoryEl = $(document).find("#id_subcategory");
         const $emptyOptionEl = $("<option></option>");
+        const $permissionOptionEl = $(document).find("#variable-permission-filter");
+        const permissionTypes = {public: 'public', private: 'private'};
+
+        filterVariables($profileEl.val(), $permissionOptionEl.find("input:checked").val());
 
         $profileEl.on('change', function (e) {
             // trigger "loadSubcategory" func only when it was manually changed
             if (e.originalEvent !== undefined) {
                 // load subcategories based on selected profile
                 loadSubcategory(e.target.value);
+                filterVariables(e.target.value, $permissionOptionEl.find("input:checked").val());
             }
         });
 
-        function appendOptionEl($outerEl, val, text){
+        $permissionOptionEl.on('change', function (e) {
+            if (e.originalEvent !== undefined) {
+                filterVariables($profileEl.val(), e.target.value);
+            }
+        });
+
+        function appendOptionEl($outerEl, val, text) {
             $outerEl.append($emptyOptionEl.clone().attr("value", val).text(text));
         }
 
@@ -37,6 +48,35 @@
             } else {
                 clearSubcategories();
             }
+        }
+
+        function filterVariables(selectedProfile, selectedPermissionType) {
+            if (selectedProfile === '' && selectedPermissionType === permissionTypes.private) {
+                $('select#id_indicator').prop('disabled', true);
+            } else {
+                $('select#id_indicator').prop('disabled', false);
+            }
+
+            $('select#id_indicator option').each(function () {
+                if (this.value !== '') {
+                    //filter out the first option
+                    let optionPermissionType = $(this).attr('data-type');
+                    let optionProfile = $(this).attr('data-profileid');
+
+                    let isHidden = false;
+                    if (selectedPermissionType === permissionTypes.public && optionPermissionType !== permissionTypes.public) {
+                        isHidden = true;
+                    } else if (selectedPermissionType === permissionTypes.private && (optionProfile !== selectedProfile || optionPermissionType !== permissionTypes.private)) {
+                        isHidden = true;
+                    }
+
+                    if (isHidden) {
+                        $(this).addClass('hidden');
+                    } else {
+                        $(this).removeClass('hidden');
+                    }
+                }
+            })
         }
     });
 })(django.jQuery);

--- a/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
+++ b/wazimap_ng/general/templates/widgets/VariableFilterWidget.html
@@ -1,15 +1,15 @@
 <div id="variable-permission-filter">
-	{{ choice_field }}
+    {{ choice_field }}
 </div>
-<select id="id_indicator" required name="{{name}}">
-<option value=''>-------------</option>
-{% for choice in choices %}
-	<option
-		value="{{ choice.id }}"
-		title="{{ choice }}"
-		data-type="{{ choice.dataset.permission_type }}"
-		class="{% if permission_type != choice.dataset.permission_type %} hidden {% endif %}"
-		{% if value.id == choice.id %} selected {% endif %}
-	> {{ choice }}</option>
-{% endfor %}
+<select id="id_indicator" required name="{{ name }}">
+    <option value=''>-------------</option>
+    {% for choice in choices %}
+        <option
+                value="{{ choice.id }}"
+                title="{{ choice }}"
+                data-type="{{ choice.dataset.permission_type }}"
+                data-profileId="{{ choice.dataset.profile.id }}"
+                {% if value.id == choice.id %} selected {% endif %}
+        > {{ choice }}</option>
+    {% endfor %}
 </select>

--- a/wazimap_ng/general/widgets.py
+++ b/wazimap_ng/general/widgets.py
@@ -9,14 +9,17 @@ from django import forms
 
 from wazimap_ng.general.services import permissions
 
+
 def customTitledFilter(title):
     class Wrapper(admin.FieldListFilter):
         def __new__(cls, *args, **kwargs):
             instance = admin.FieldListFilter.create(*args, **kwargs)
             instance.title = title
             return instance
+
     return Wrapper
-    
+
+
 def description(description, func):
     func.short_description = description
     return func
@@ -38,6 +41,7 @@ class SortableWidget(Widget):
             'values': values
         }}
 
+
 class VariableFilterWidget(Widget):
     template_name = 'widgets/VariableFilterWidget.html'
 
@@ -46,9 +50,9 @@ class VariableFilterWidget(Widget):
         js = ("/static/js/variable-filter-widget.js",)
 
     def get_context(self, name, value, attrs=None):
-
         CHOICES = [('public', 'All public variables'), ('private', 'Private variables of the selected profile')]
         choice_field = forms.fields.ChoiceField(widget=forms.RadioSelect, choices=CHOICES)
+
         queryset = self.choices.queryset.order_by(
             'dataset__profile__name',
             'dataset__name',


### PR DESCRIPTION
## Description
Fix issue of the server running out of memory while executing an indicator data extraction task

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-265

## How to test it locally
* Create a variable and check RAM usage for task execution
* Switch branch to this fix
* Create variable with same group & dataset and observe RAM usage
* RAM usage and task execution time should be reduced
To check memory consumption use: docker stats or htop

## Changelog
Updated indicator data task to use values to get specific data
removed use of bulk_create
formatted using black

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
