### PR TITLE
Fix issue of universe not working for data extraction

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -192,8 +192,7 @@ def indicator(dataset):
 
 
 @pytest.fixture
-def datasetdata(indicator, geography):
-    dataset = indicator.dataset
+def datasetdata(dataset, geography):
 
     return [
         DatasetDataFactory(dataset=dataset, geography=geography, data={

--- a/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
+++ b/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
@@ -20,6 +20,15 @@ def universe():
         filters={"gender": "female", "age__lt": "17"}
     )
 
+@pytest.fixture
+def indicator_with_universe(dataset, universe):
+    subindicators = ["male", "female"]
+    groups = ["gender"]
+    return IndicatorFactory(
+        dataset=dataset, subindicators=subindicators, groups=groups,
+        universe=universe
+    )
+
 @pytest.mark.django_db
 @pytest.mark.usefixtures("datasetdata")
 class TestIndicatorDataExtraction:
@@ -64,12 +73,8 @@ class TestIndicatorDataExtraction:
             idata = IndicatorData.objects.get(geography=g)
             assert idata.data[0]["geography"] == g.pk
 
-    def test_universe(self, indicator, geography, universe):
-        # Add universe to indicator
-        indicator.universe = universe
-        indicator.save()
-
-        indicator_data_extraction(indicator, universe=universe)
+    def test_universe(self, geography, indicator_with_universe):
+        indicator_data_extraction(indicator_with_universe)
         indicator_data = IndicatorData.objects.get(geography=geography)
 
         assert indicator_data.data == [

--- a/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
+++ b/tests/datasets/tasks/indicator_data_extraction/test_extraction.py
@@ -5,13 +5,20 @@ from tests.datasets.factories import (
     DatasetFileFactory,
     GeographyFactory,
     GeographyHierarchyFactory,
-    IndicatorFactory
+    IndicatorFactory,
+    UniverseFactory
 )
 from wazimap_ng.datasets.models import Geography, IndicatorData
 from wazimap_ng.datasets.tasks.indicator_data_extraction import (
     indicator_data_extraction
 )
 
+
+@pytest.fixture
+def universe():
+    return UniverseFactory(
+        filters={"gender": "female", "age__lt": "17"}
+    )
 
 @pytest.mark.django_db
 @pytest.mark.usefixtures("datasetdata")
@@ -57,8 +64,10 @@ class TestIndicatorDataExtraction:
             idata = IndicatorData.objects.get(geography=g)
             assert idata.data[0]["geography"] == g.pk
 
-    def test_universe(self, indicator, geography):
-        universe = {"data__gender": "female", "data__age__lt": "17"}
+    def test_universe(self, indicator, geography, universe):
+        # Add universe to indicator
+        indicator.universe = universe
+        indicator.save()
 
         indicator_data_extraction(indicator, universe=universe)
         indicator_data = IndicatorData.objects.get(geography=geography)

--- a/wazimap_ng/datasets/models/datasetdata.py
+++ b/wazimap_ng/datasets/models/datasetdata.py
@@ -11,13 +11,6 @@ from django.contrib.postgres.fields.jsonb import KeyTextTransform
 
 
 class DatasetDataQuerySet(models.QuerySet):
-    def filter_by_universe(self, universe):
-        filters = universe.filters
-        if filters and isinstance(filters, dict):
-            filters = {f"data__{k}": v for k, v in filters.items()}
-            return self.filter(**filters)
-        else:
-            return self
 
     def get_unique_subindicators(self, group):
 

--- a/wazimap_ng/datasets/tasks/indicator_data_extraction.py
+++ b/wazimap_ng/datasets/tasks/indicator_data_extraction.py
@@ -9,8 +9,15 @@ logger = logging.getLogger(__name__)
 
 
 @transaction.atomic
-def indicator_data_extraction(indicator, *args, universe={}, **kwargs):
+def indicator_data_extraction(indicator, *args, **kwargs):
     indicator.indicatordata_set.all().delete()
+
+    universe = {}
+    if indicator.universe and isinstance(indicator.universe.filters, dict):
+        universe = {
+            f"data__{key}": value for key, value in indicator.universe.filters.items()
+        }
+
     geography_ids = (
         models.DatasetData.objects.filter(dataset=indicator.dataset)
         .filter(**universe)

--- a/wazimap_ng/datasets/tasks/indicator_data_extraction.py
+++ b/wazimap_ng/datasets/tasks/indicator_data_extraction.py
@@ -12,15 +12,15 @@ logger = logging.getLogger(__name__)
 def indicator_data_extraction(indicator, *args, **kwargs):
     indicator.indicatordata_set.all().delete()
 
-    universe = {}
+    datasetdata_filters = {}
     if indicator.universe and isinstance(indicator.universe.filters, dict):
-        universe = {
+        datasetdata_filters = {
             f"data__{key}": value for key, value in indicator.universe.filters.items()
         }
 
     geography_ids = (
         models.DatasetData.objects.filter(dataset=indicator.dataset)
-        .filter(**universe)
+        .filter(**datasetdata_filters)
         .values_list("geography_id", flat=True)
         .order_by("geography_id")
         .distinct()
@@ -33,7 +33,7 @@ def indicator_data_extraction(indicator, *args, **kwargs):
                 models.DatasetData.objects.filter(
                     dataset=indicator.dataset, geography_id=g
                 )
-                .filter(**universe)
+                .filter(**datasetdata_filters)
                 .order_by("id")
                 .values_list("data", flat=True)
             ),


### PR DESCRIPTION
## Description
The universe was not working for indicator data filters.
It is the way we can filter data inside indicator data. ex : Get all Male under 20 `{"gender": "male", "age__lt": "20"}` 
Previously indicator data task expected that we pass the universe from the task but now changed the approach to check if the indicator has a universe object and if there is a universe object present add it to filters.

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-332

## How to test it locally
Add universe to indicator
save variable and wait for the task to complete
Check indicator data results to verify

## Changelog
Changed indicator extraction process
Fixed tests accordingly

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
