### PR TITLE
show validations errors for uploaded file via admin panel

### DIFF
--- a/tests/datasets/admin/test_dataset_admin.py
+++ b/tests/datasets/admin/test_dataset_admin.py
@@ -384,7 +384,8 @@ class TestDatasetUploadValidations:
         data={
             'metadata-TOTAL_FORMS': 0,
             'metadata-INITIAL_FORMS': 0,
-            'import_dataset': csv_file
+            'import_dataset': csv_file,
+            'content_type': "quantitative",
         }
         res = client.post(url, data, follow=True)
 

--- a/tests/datasets/tasks/test_process_uploaded_file.py
+++ b/tests/datasets/tasks/test_process_uploaded_file.py
@@ -21,9 +21,11 @@ def create_datasetfile(file_data, encoding, header, dataset_id):
     csv_file = SimpleUploadedFile(
         name="test.csv", content=content, content_type='text/csv'
     )
-    return DatasetFileFactory(
+    file_obj = DatasetFileFactory(
         document=csv_file, dataset_id=dataset_id
     )
+    file_obj.full_clean()
+    return file_obj
 
 good_data = [
     ["GEOCODE_1", "F1_value_1", "F2_value_1", 111],

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -177,7 +177,7 @@ class TestDatasetUploadView(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"] ==
-            "Invalid File passed. We were not able to find Required header : Geography"
+            "Invalid File passed. We were not able to find Required header : Geography, Count"
         )
 
         data = [["Geography", "test"], ["ZA", "x1"]]
@@ -392,7 +392,7 @@ class TestDatasetUploadView(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"] ==
-            "Invalid File passed. We were not able to find Required header : Geography"
+            "Invalid File passed. We were not able to find Required header : Geography, Contents"
         )
 
         data = [["Geography", "test"], ["ZA", "x1"]]

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -176,7 +176,7 @@ class TestDatasetUploadView(APITestCase):
 
         assert response.status_code == 400
         assert (
-            response.data["detail"] == 
+            response.data["detail"] ==
             "Invalid File passed. We were not able to find Required header : Geography"
         )
 
@@ -194,7 +194,7 @@ class TestDatasetUploadView(APITestCase):
 
         assert response.status_code == 400
         assert (
-            response.data["detail"] == 
+            response.data["detail"] ==
             "Invalid File passed. We were not able to find Required header : Count"
         )
 

--- a/tests/datasets/test_views.py
+++ b/tests/datasets/test_views.py
@@ -177,7 +177,7 @@ class TestDatasetUploadView(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"] == 
-            "Invalid File passed. We were not able to find Required header : Geography "
+            "Invalid File passed. We were not able to find Required header : Geography"
         )
 
         data = [["Geography", "test"], ["ZA", "x1"]]
@@ -195,7 +195,7 @@ class TestDatasetUploadView(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"] == 
-            "Invalid File passed. We were not able to find Required header : Count "
+            "Invalid File passed. We were not able to find Required header : Count"
         )
 
     def test_validation_for_creating_dataset(self):
@@ -392,7 +392,7 @@ class TestDatasetUploadView(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"] ==
-            "Invalid File passed. We were not able to find Required header : Geography "
+            "Invalid File passed. We were not able to find Required header : Geography"
         )
 
         data = [["Geography", "test"], ["ZA", "x1"]]
@@ -411,7 +411,7 @@ class TestDatasetUploadView(APITestCase):
         assert response.status_code == 400
         assert (
             response.data["detail"] ==
-            "Invalid File passed. We were not able to find Required header : Contents "
+            "Invalid File passed. We were not able to find Required header : Contents"
         )
 
     def test_request_for_adding_qualitative_dataset(self):

--- a/wazimap_ng/datasets/models/upload.py
+++ b/wazimap_ng/datasets/models/upload.py
@@ -52,11 +52,11 @@ def validate_uploaded_file(document, content_type):
     else:
         required_headers.append("contents")
 
-    for required_header in required_headers:
-        if required_header not in headers:
-            raise ValidationError(
-                "Invalid File passed. We were not able to find Required header : %s" % required_header.capitalize()
-            )
+    missing_headers = [h.capitalize() for h in list(set(required_headers) - set(headers))]
+    if missing_headers:
+        raise ValidationError(
+            f"Invalid File passed. We were not able to find Required header : {', ' .join(missing_headers)}"
+        )
 
 def get_file_path(instance, filename):
     filename = utils.get_random_filename(filename)

--- a/wazimap_ng/datasets/models/upload.py
+++ b/wazimap_ng/datasets/models/upload.py
@@ -78,13 +78,8 @@ class DatasetFile(BaseModel, SimpleHistory):
     name = name = models.CharField(max_length=60)
     dataset_id = models.PositiveSmallIntegerField(null=True, blank=True)
 
-
     def __str__(self):
         return self.name
-
-    def save(self, *args, **kwargs):
-        self.full_clean()
-        return super().save(*args, **kwargs)
 
     def clean(self):
         """

--- a/wazimap_ng/datasets/models/upload.py
+++ b/wazimap_ng/datasets/models/upload.py
@@ -27,6 +27,37 @@ def file_size(value):
     if value.size > max_filesize:
         raise ValidationError(f"File too large. Size should not exceed {max_filesize / (1024 * 1024)} MiB.")
 
+def validate_uploaded_file(document, content_type):
+    document_name = document.name
+    headers = []
+    try:
+        if "xls" in document_name or "xlsx" in document_name:
+            book = xlrd.open_workbook(file_contents=document.read())
+            headers = pd.read_excel(book, nrows=1, dtype=str).columns.str.lower().str.strip()
+        elif "csv" in document_name:
+            headers = pd.read_csv(BytesIO(document.read()), nrows=1, dtype=str).columns.str.lower().str.strip()
+    except pd.errors.ParserError as e:
+        raise ValidationError(
+            "Not able to parse passed file. Error while reading file: %s" % str(e)
+        )
+    except pd.errors.EmptyDataError as e:
+        raise ValidationError(
+            "File seems to be empty. Error while reading file: %s" % str(e)
+        )
+
+    required_headers = ["geography"]
+
+    if content_type == QUANTITATIVE:
+        required_headers.append("count")
+    else:
+        required_headers.append("contents")
+
+    for required_header in required_headers:
+        if required_header not in headers:
+            raise ValidationError(
+                "Invalid File passed. We were not able to find Required header : %s" % required_header.capitalize()
+            )
+
 def get_file_path(instance, filename):
     filename = utils.get_random_filename(filename)
     return os.path.join('datasets', filename)
@@ -39,7 +70,7 @@ class DatasetFile(BaseModel, SimpleHistory):
             file_size
         ],
         help_text=f"""
-            Uploaded document should be less than {max_filesize / (1024 * 1024)} MiB in size and 
+            Uploaded document should be less than {max_filesize / (1024 * 1024)} MiB in size and
             file extensions should be one of {", ".join(allowed_file_extensions)}.
         """
     )
@@ -60,24 +91,6 @@ class DatasetFile(BaseModel, SimpleHistory):
         Cleaner for Document model.
         Check uploaded files and see if header contains Geography & Count
         """
-        document_name = self.document.name
-        headers = []
-        try:
-            if "xls" in document_name or "xlsx" in document_name:
-                book = xlrd.open_workbook(file_contents=self.document.read())
-                headers = pd.read_excel(book, nrows=1, dtype=str).columns.str.lower().str.strip()
-            elif "csv" in document_name:
-                headers = pd.read_csv(BytesIO(self.document.read()), nrows=1, dtype=str).columns.str.lower().str.strip()
-        except pd.errors.ParserError as e:
-            raise ValidationError(
-                "Not able to parse passed file. Error while reading file: %s" % str(e)
-            )
-        except pd.errors.EmptyDataError as e:
-            raise ValidationError(
-                "File seems to be empty. Error while reading file: %s" % str(e)
-            )
-
-        required_headers = ["geography"]
         try:
             dataset = Dataset.objects.get(id=self.dataset_id)
         except Dataset.DoesNotExist:
@@ -85,14 +98,4 @@ class DatasetFile(BaseModel, SimpleHistory):
             raise ValidationError(
                 "Datset not found while uploading dataset file"
             )
-
-        if dataset.content_type == QUANTITATIVE:
-            required_headers.append("count")
-        else:
-            required_headers.append("contents")
-
-        for required_header in required_headers:
-            if required_header not in headers:
-                raise ValidationError(
-                    "Invalid File passed. We were not able to find Required header : %s " % required_header.capitalize()
-                )
+        validate_uploaded_file(self.document, dataset.content_type)

--- a/wazimap_ng/datasets/views.py
+++ b/wazimap_ng/datasets/views.py
@@ -48,11 +48,13 @@ class DatasetList(generics.ListCreateAPIView):
         file_obj = request.data.get('file', None)
         if file_obj:
             try:
-                datasetfile_obj = models.DatasetFile.objects.create(
+                datasetfile_obj = models.DatasetFile(
                     name=dataset_obj.name,
                     document=file_obj,
                     dataset_id=dataset_obj.id
                 )
+                datasetfile_obj.full_clean()
+                datasetfile_obj.save()
             except Exception as err:
                 return Response({
                     'detail': ', '.join(err.messages)


### PR DESCRIPTION
## Description
Show validation errors for an uploaded file in admin panel.
Any validation error in models save throws 500 and is not handled by admin forms.
We have added save validations to the Django admin form field and clean method
We still require it at a model level as we can also upload file from API and it is using those validations

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-240

## How to test it locally
Try to upload the file without count and check if the admin panel shows a form error while saving

## Changelog
* Added validations to dataset admin form
* Added tests
* Made a common method to test required headers validation

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
