### PR TITLE
removed mkdocs from requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ django-cors-headers==3.2.0
 # Developer Tools
 ipdb==0.11
 ipython==7.28.0
-mkdocs==1.0.4
 flake8==3.7.5
 django-debug-toolbar==2.2.1
 sentry-sdk==0.16.1


### PR DESCRIPTION
## Description
removed mkdocs from requirements because it is not used and it causes dependabot alerts

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-353

## How to test it locally

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [ ]  ✅ added (appropriate) unit tests
- [ ]  💢 edge cases in tests were considered
- [ ]  ✅ ran tests locally & are passing
