### PR TITLE
Fix timeout issue while saving indicator for first time

### DIFF
--- a/tests/datasets/models/test_indicator.py
+++ b/tests/datasets/models/test_indicator.py
@@ -4,15 +4,13 @@ from unittest.mock import Mock
 from wazimap_ng.datasets.models import Indicator, Dataset, DatasetData
 
 class TestIndicatorGetUniqueSubindicators:
-    @patch("wazimap_ng.datasets.models.DatasetData.objects")
-    def test_get_subindicators(self, mock_datasetdata_objects):
+    @patch("wazimap_ng.datasets.models.Group.objects")
+    def test_get_subindicators(self, mock_group_objects):
         indicator = Indicator()
         indicator.groups = ["A", "B"]
         indicator.dataset = Dataset()
-
-        mock_datasetdata_objects.filter.return_value.get_unique_subindicators.return_value = [1, 2, 3]
+        mock_group_objects.filter.return_value.first.return_value.subindicators = [1, 2, 3]
         subindicators = indicator.get_unique_subindicators()
-
         assert subindicators == [1, 2, 3]
 
     @patch("wazimap_ng.datasets.models.DatasetData.objects")

--- a/wazimap_ng/datasets/admin/indicator_data_admin.py
+++ b/wazimap_ng/datasets/admin/indicator_data_admin.py
@@ -11,6 +11,7 @@ from wazimap_ng.general.admin import filters
 
 @admin.register(models.IndicatorData)
 class IndicatorDataAdmin(DatasetBaseAdminModel):
+    autocomplete_fields = ("geography", )
 
     def indicator__name(self, obj):
         return obj.indicator.name

--- a/wazimap_ng/datasets/models/indicator.py
+++ b/wazimap_ng/datasets/models/indicator.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.contrib.postgres.fields import JSONField, ArrayField
 
 from .dataset import Dataset
+from .group import Group
 from .datasetdata import DatasetData
 from .universe import Universe
 from wazimap_ng.general.models import BaseModel, SimpleHistory
@@ -22,13 +23,16 @@ class Indicator(BaseModel, SimpleHistory):
     subindicators = JSONField(default=list, blank=True, null=True)
 
     def get_unique_subindicators(self):
+        subindicators = []
         if len(self.groups) > 0:
-            # TODO this model should be refactored to only allow one group
             group = self.groups[0]
-            subindicators = DatasetData.objects.filter(dataset=self.dataset).get_unique_subindicators(group)
-            return list(subindicators)
+            subindicator_group = Group.objects.filter(
+                dataset=self.dataset, name=group
+            ).first()
+            if subindicator_group:
+                subindicators = subindicator_group.subindicators
 
-        return []
+        return subindicators
 
     def save(self, force_subindicator_update=False, *args, **kwargs):
         first_save = operator.not_(self.subindicators)


### PR DESCRIPTION
## Description
Timeout issue was coming because we were fetching dataset data queryset and filtering out unique sub-indicators on first save of variable.
For big datasets, it was taking too much time and the admin throws timeout error.

Fixed it by replacing query to get subindicators from Subindicator Groups

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-328

## How to test it locally
Not able to reproduce in local
To test on staging server:
* Go to variable add page
* search for dataset `Language - Mainplace and Subplace`
* select language in groups
* Save

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
