### PR TITLE
validating the required headers while uploading points data

### DIFF
--- a/tests/points/admin/test_category_admin.py
+++ b/tests/points/admin/test_category_admin.py
@@ -13,9 +13,9 @@ class TestCategoryAdmin:
         csv.writer(csvfile).writerows(data)
         return csvfile.getvalue()
 
-    def test_uploading_file_with_missing_headers(self, client, superuser):
+    def test_uploading_file_with_no_longitude(self, client, superuser):
         """
-        Test validation for uploading a file without longitude
+        Test validation for uploading a file without Longitude
         """
         client.force_login(user=superuser)
         url = reverse("admin:points_category_add")
@@ -38,3 +38,80 @@ class TestCategoryAdmin:
 
         assert errors["__all__"].data[
                    0].message == 'Invalid File passed. We were not able to find Required header : Longitude'
+
+    def test_uploading_file_with_no_latitude(self, client, superuser):
+        """
+        Test validation for uploading a file without Latitude
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:points_category_add")
+        data = [["name", "longitude", "id", "status", "status last updated", "class", "volume",
+                 "discharges into"],
+                ["Molopo Millitary Base WWTW", "25.6223485469818", "S_2688", "Bad",
+                 "16th March 2022", "Class E", "700 Kl/day", "Unknown"]]
+        content = self.create_csv_file(data).encode("utf-8")
+        csv_file = SimpleUploadedFile(
+            name="test.csv", content=content, content_type='text/csv'
+        )
+        form_data = {
+            'import_collection': csv_file,
+        }
+        res = client.post(url, form_data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+        errors = form.errors
+
+        assert errors["__all__"].data[
+                   0].message == 'Invalid File passed. We were not able to find Required header : Latitude'
+
+    def test_uploading_file_with_no_name(self, client, superuser):
+        """
+        Test validation for uploading a file without Name
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:points_category_add")
+        data = [["longitude", "latitude", "id", "status", "status last updated", "class", "volume",
+                 "discharges into"],
+                ["25.6223485469818", "-25.7632126977988", "S_2688", "Bad",
+                 "16th March 2022", "Class E", "700 Kl/day", "Unknown"]]
+        content = self.create_csv_file(data).encode("utf-8")
+        csv_file = SimpleUploadedFile(
+            name="test.csv", content=content, content_type='text/csv'
+        )
+        form_data = {
+            'import_collection': csv_file,
+        }
+        res = client.post(url, form_data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+        errors = form.errors
+
+        assert errors["__all__"].data[
+                   0].message == 'Invalid File passed. We were not able to find Required header : Name'
+
+    def test_uploading_file_missing_non_required_column(self, client, superuser):
+        """
+        Test validation for uploading a file without id. There should be no validation errors
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:points_category_add")
+        data = [["name", "longitude", "latitude", "status", "status last updated", "class", "volume",
+                 "discharges into"],
+                ["Molopo Millitary Base WWTW", "25.6223485469818", "-25.7632126977988", "Bad",
+                 "16th March 2022", "Class E", "700 Kl/day", "Unknown"]]
+        content = self.create_csv_file(data).encode("utf-8")
+        csv_file = SimpleUploadedFile(
+            name="test.csv", content=content, content_type='text/csv'
+        )
+        form_data = {
+            'import_collection': csv_file,
+        }
+        res = client.post(url, form_data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+        errors = form.errors
+
+        assert (('__all__' in errors) is False)

--- a/tests/points/admin/test_category_admin.py
+++ b/tests/points/admin/test_category_admin.py
@@ -1,0 +1,40 @@
+import pytest
+import csv
+from io import StringIO
+
+from django.urls import reverse
+from django.core.files.uploadedfile import SimpleUploadedFile
+
+
+@pytest.mark.django_db
+class TestCategoryAdmin:
+    def create_csv_file(self, data):
+        csvfile = StringIO()
+        csv.writer(csvfile).writerows(data)
+        return csvfile.getvalue()
+
+    def test_uploading_file_with_missing_headers(self, client, superuser):
+        """
+        Test validation for uploading a file without longitude
+        """
+        client.force_login(user=superuser)
+        url = reverse("admin:points_category_add")
+        data = [["name", "latitude", "id", "status", "status last updated", "class", "volume",
+                 "discharges into"],
+                ["Molopo Millitary Base WWTW", "-25.7632126977988", "S_2688", "Bad",
+                 "16th March 2022", "Class E", "700 Kl/day", "Unknown"]]
+        content = self.create_csv_file(data).encode("utf-8")
+        csv_file = SimpleUploadedFile(
+            name="test.csv", content=content, content_type='text/csv'
+        )
+        form_data = {
+            'import_collection': csv_file,
+        }
+        res = client.post(url, form_data, follow=True)
+
+        assert res.status_code == 200
+        form = res.context['adminform'].form
+        errors = form.errors
+
+        assert errors["__all__"].data[
+                   0].message == 'Invalid File passed. We were not able to find Required header : Longitude'

--- a/wazimap_ng/points/admin/forms/category_admin_form.py
+++ b/wazimap_ng/points/admin/forms/category_admin_form.py
@@ -30,21 +30,19 @@ class CategoryAdminForm(HistoryAdminForm):
     def clean(self):
         cleaned_data = super(CategoryAdminForm, self).clean()
         document = cleaned_data.get('import_collection', None)
-        headers = pd.read_csv(BytesIO(document.read()), nrows=1, dtype=str).columns.str.lower().str.strip()
         required_headers = ["name", "longitude", "latitude", "id", "status", "status last updated", "class", "volume",
                             "discharges into"]
-        missing_headers = [
-            h.capitalize() for h in list(set(required_headers) - set(headers))
-        ]
+        if document is not None:
+            headers = pd.read_csv(BytesIO(document.read()), nrows=1, dtype=str).columns.str.lower().str.strip()
+            missing_headers = [
+                h.capitalize() for h in list(set(required_headers) - set(headers))
+            ]
 
-        if missing_headers:
-            missing_headers.sort()
-            raise ValidationError(
-                f"Invalid File passed. We were not able to find Required header : {', '.join(missing_headers)}"
-            )
-
-        print({'headers': headers})
-        print({'missing_headers': missing_headers})
+            if missing_headers:
+                missing_headers.sort()
+                raise ValidationError(
+                    f"Invalid File passed. We were not able to find Required header : {', '.join(missing_headers)}"
+                )
 
     def save(self, commit=True):
         if self.has_changed():

--- a/wazimap_ng/points/admin/forms/category_admin_form.py
+++ b/wazimap_ng/points/admin/forms/category_admin_form.py
@@ -5,6 +5,11 @@ from wazimap_ng.general.models import MetaData
 from wazimap_ng.general.admin.forms import HistoryAdminForm
 from ... import models
 
+from io import BytesIO
+import pandas as pd
+
+from django.core.exceptions import ValidationError
+
 
 class CategoryAdminForm(HistoryAdminForm):
     source = forms.CharField(widget=forms.TextInput(attrs={'class': 'vTextField'}), required=False)
@@ -21,6 +26,25 @@ class CategoryAdminForm(HistoryAdminForm):
                 self.fields["source"].initial = metadata.source
                 self.fields["description"].initial = metadata.description
                 self.fields["licence"].initial = metadata.licence
+
+    def clean(self):
+        cleaned_data = super(CategoryAdminForm, self).clean()
+        document = cleaned_data.get('import_collection', None)
+        headers = pd.read_csv(BytesIO(document.read()), nrows=1, dtype=str).columns.str.lower().str.strip()
+        required_headers = ["name", "longitude", "latitude", "id", "status", "status last updated", "class", "volume",
+                            "discharges into"]
+        missing_headers = [
+            h.capitalize() for h in list(set(required_headers) - set(headers))
+        ]
+
+        if missing_headers:
+            missing_headers.sort()
+            raise ValidationError(
+                f"Invalid File passed. We were not able to find Required header : {', '.join(missing_headers)}"
+            )
+
+        print({'headers': headers})
+        print({'missing_headers': missing_headers})
 
     def save(self, commit=True):
         if self.has_changed():

--- a/wazimap_ng/points/admin/forms/category_admin_form.py
+++ b/wazimap_ng/points/admin/forms/category_admin_form.py
@@ -30,8 +30,7 @@ class CategoryAdminForm(HistoryAdminForm):
     def clean(self):
         cleaned_data = super(CategoryAdminForm, self).clean()
         document = cleaned_data.get('import_collection', None)
-        required_headers = ["name", "longitude", "latitude", "id", "status", "status last updated", "class", "volume",
-                            "discharges into"]
+        required_headers = ["name", "longitude", "latitude"]
         if document is not None:
             headers = pd.read_csv(BytesIO(document.read()), nrows=1, dtype=str).columns.str.lower().str.strip()
             missing_headers = [

--- a/wazimap_ng/points/models.py
+++ b/wazimap_ng/points/models.py
@@ -103,30 +103,3 @@ class CoordinateFile(BaseModel, SimpleHistory):
 
     def __str__(self):
         return self.name
-
-    def clean(self):
-        """
-        Clean points data
-        """
-        document_name = self.document.name
-        headers = []
-        try:
-            headers = pd.read_csv(
-                BytesIO(self.document.read()), nrows=1, dtype=str
-            ).columns.str.lower()
-        except pd.errors.ParserError as e:
-            raise ValidationError(
-                "Not able to parse passed file. Error while reading file: %s" % str(e)
-            )
-        except pd.errors.EmptyDataError as e:
-            raise ValidationError(
-                "File seems to be empty. Error while reading file: %s" % str(e)
-            )
-
-        required_headers = ["longitude", "latitude", "name"]
-
-        for required_header in required_headers:
-            if required_header not in headers:
-                raise ValidationError(
-                    "Invalid File passed. We were not able to find Required header : %s " % required_header.capitalize()
-                )


### PR DESCRIPTION
## Description
handling the errors that occurs when points data upload is missing required columns. assumed required columns are : 
* name
* longitude
* latitude

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-274

## How to test it locally
* navigate to admin panel
* try to create a collection by uploading a file that does not contain any of the columns above
* confirm that you get a validation error

![image](https://user-images.githubusercontent.com/53019884/169409963-f032d848-18bb-4164-b4c4-3a16f0ea9d8b.png)


## Changelog

### Added
* `tests/points/admin/test_category_admin.py` for automated tests

### Updated
* `wazimap_ng/points/admin/forms/category_admin_form.py` to add the `clean` method for validations

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
