### PR TITLE
Sanitize location admin action name to ignore format strings

### DIFF
--- a/tests/points/admin/test_location_admin.py
+++ b/tests/points/admin/test_location_admin.py
@@ -40,11 +40,11 @@ def test_location_action_choices(
     location_admin = LocationAdmin(model=Location, admin_site=AdminSite())
     # assert actions
     actions = location_admin.get_actions(mocked_request)
-    assert actions["assign_to_category_1"][2] == "Assign to test %% change"
-    assert actions["delete_selected"][2] == "Delete selected %(verbose_name_plural)s"
+    assert actions[f'assign_to_category_{category.id}'][2] == 'Assign to test %% change'
+    assert actions['delete_selected'][2] == 'Delete selected %(verbose_name_plural)s'
 
     # assert action choices to be displayed
     action_choices = location_admin.get_action_choices(mocked_request)
     assert action_choices[0] == ('', '---------')
     assert action_choices[1] == ('delete_selected', 'Delete selected locations')
-    assert action_choices[2] == ('assign_to_category_1', 'Assign to test % change')
+    assert action_choices[2] == (f'assign_to_category_{category.id}', 'Assign to test % change')

--- a/tests/points/admin/test_location_admin.py
+++ b/tests/points/admin/test_location_admin.py
@@ -6,7 +6,7 @@ from django.contrib.gis.geos import Point
 from wazimap_ng.points.models import Location
 from wazimap_ng.points.admin import LocationAdmin
 
-from tests.points.factories import LocationFactory
+from tests.points.factories import LocationFactory, CategoryFactory
 
 @pytest.fixture()
 def test_location():
@@ -29,3 +29,22 @@ def test(admin_user, rf, test_location):
 
     assert "image" not in form.errors
     assert "data" not in form.errors
+
+@pytest.mark.django_db
+def test_location_action_choices(
+    admin_user, rf, mocked_request, profile
+):
+    category = CategoryFactory(
+        profile=profile, name="test % change"
+    )
+    location_admin = LocationAdmin(model=Location, admin_site=AdminSite())
+    # assert actions
+    actions = location_admin.get_actions(mocked_request)
+    assert actions["assign_to_category_1"][2] == "Assign to test %% change"
+    assert actions["delete_selected"][2] == "Delete selected %(verbose_name_plural)s"
+
+    # assert action choices to be displayed
+    action_choices = location_admin.get_action_choices(mocked_request)
+    assert action_choices[0] == ('', '---------')
+    assert action_choices[1] == ('delete_selected', 'Delete selected locations')
+    assert action_choices[2] == ('assign_to_category_1', 'Assign to test % change')

--- a/wazimap_ng/points/admin/location_admin.py
+++ b/wazimap_ng/points/admin/location_admin.py
@@ -17,10 +17,10 @@ from .. import models
 def assign_to_category_action(category):
     def assign_to_category(modeladmin, request, queryset):
         queryset.update(category=category)
-        messages.info(request, "Locations assigned to category {0}".format(category.name))
+        messages.info(request, f"Locations assigned to category {category.name}")
 
-    assign_to_category.short_description = "Assign to {0}".format(category.name)
-    assign_to_category.__name__ = 'assign_to_category_{0}'.format(category.id)
+    assign_to_category.short_description = f'Assign to {category.name.replace("%", "%%")}'
+    assign_to_category.__name__ = f'assign_to_category_{category.id}'
 
     return assign_to_category
 

--- a/wazimap_ng/points/admin/location_admin.py
+++ b/wazimap_ng/points/admin/location_admin.py
@@ -19,6 +19,8 @@ def assign_to_category_action(category):
         queryset.update(category=category)
         messages.info(request, f"Locations assigned to category {category.name}")
 
+    # Escape for %-formatting applied to action descriptions
+    # https://docs.python.org/3/library/stdtypes.html#printf-style-string-formatting
     assign_to_category.short_description = f'Assign to {category.name.replace("%", "%%")}'
     assign_to_category.__name__ = f'assign_to_category_{category.id}'
 


### PR DESCRIPTION
## Description
In location admin we are using category name in action description
It threw error if there was a % sing in name as python treated it as format string.
Fixed by adding double % sign if % is present.
https://stackoverflow.com/questions/26393895/python-how-to-escape-s/26393941#26393941
I think it's most feasible solution as we do not want to remove % sign

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-447

## How to test it locally
* Add % sign in any collection name.
* Try to open location admin list page
* Page should open up without any problems

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
