### PR TITLE
Profile highlight & Profile key metrics UI changes

### DIFF
--- a/tests/profile/admin/test_profile_highlights_admin.py
+++ b/tests/profile/admin/test_profile_highlights_admin.py
@@ -16,7 +16,7 @@ class TestProfileHighlightAdmin:
 
     def test_indicator_queryset_excludes_qualitative_indicator(
             self, mocked_request, indicator, qualitative_indicator
-        ):
+    ):
         ma = ProfileHighlightAdmin(ProfileHighlight, AdminSite())
         # Assert that there are both quantative and qualitative type of indicator available
         indicators = Indicator.objects.all()
@@ -30,3 +30,11 @@ class TestProfileHighlightAdmin:
         assert queryset.count() == 1
         assert queryset.first().id == indicator.id
         assert indicator.dataset.content_type == "quantitative"
+
+    def test_fieldset(self, mocked_request, profile_highlight):
+        ma = ProfileHighlightAdmin(ProfileHighlight, AdminSite())
+        base_fields = list(ma.get_form(mocked_request, profile_highlight).base_fields)
+
+        assert base_fields == [
+            "label", "indicator", "subindicator", "denominator", "change_reason"
+        ]

--- a/tests/profile/admin/test_profile_key_metrics_admin.py
+++ b/tests/profile/admin/test_profile_key_metrics_admin.py
@@ -7,6 +7,7 @@ from wazimap_ng.profile.admin.admins import ProfileKeyMetricsAdmin
 from wazimap_ng.profile.models import ProfileKeyMetrics
 from wazimap_ng.datasets.models import Indicator
 
+
 @pytest.mark.django_db
 class TestProfileKeyMetricsAdmin:
 
@@ -14,10 +15,9 @@ class TestProfileKeyMetricsAdmin:
         ma = ProfileKeyMetricsAdmin(ProfileKeyMetrics, AdminSite())
         assert str(ma) == 'profile.ProfileKeyMetricsAdmin'
 
-
     def test_variable_queryset_excludes_qualitative_indicator(
             self, mocked_request, indicator, qualitative_indicator
-        ):
+    ):
         ma = ProfileKeyMetricsAdmin(ProfileKeyMetrics, AdminSite())
 
         # Assert that there are both quantative and qualitative type of indicator available
@@ -32,3 +32,11 @@ class TestProfileKeyMetricsAdmin:
         assert queryset.count() == 1
         assert queryset.first().id == indicator.id
         assert indicator.dataset.content_type == "quantitative"
+
+    def test_fieldset(self, mocked_request, profile_key_metric):
+        ma = ProfileKeyMetricsAdmin(ProfileKeyMetrics, AdminSite())
+        base_fields = list(ma.get_form(mocked_request, profile_key_metric).base_fields)
+
+        assert base_fields == [
+            "subcategory", "label", "variable", "subindicator", "denominator", "change_reason"
+        ]

--- a/wazimap_ng/profile/admin/admins/profile_highlight_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_highlight_admin.py
@@ -13,34 +13,30 @@ from wazimap_ng.general.admin import filters
 
 @admin.register(models.ProfileHighlight)
 class ProfileHighlightAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
-
-    list_filter = (filters.ProfileNameFilter, )
+    list_filter = (filters.ProfileNameFilter,)
 
     exclude_common_list_display = True
     list_display = (
-        "profile", 
-        "label", 
+        "profile",
+        "label",
         description("Indicator", lambda x: x.indicator.name),
         "created",
         "updated",
-        "order", 
+        "order",
     )
 
     fieldsets = (
-        ("Database fields (can't change after being created)", {
-            "fields": ("profile", "indicator")
-        }),
         ("Profile fields", {
-          "fields": ("label", "subindicator", "denominator")
-        })
+            "fields": ("profile", "label", "indicator", "subindicator", "denominator")
+        }),
     )
     form = ProfileHighlightForm
-    search_fields = ("label", )
+    search_fields = ("label",)
 
     help_texts = ["denominator", ]
 
     def get_readonly_fields(self, request, obj=None):
-        if obj: # editing an existing object
+        if obj:  # editing an existing object
             return ("profile",) + self.readonly_fields
         return self.readonly_fields
 

--- a/wazimap_ng/profile/admin/admins/profile_key_metrics_admin.py
+++ b/wazimap_ng/profile/admin/admins/profile_key_metrics_admin.py
@@ -9,13 +9,12 @@ from wazimap_ng.general.admin.admin_base import BaseAdminModel, HistoryAdmin
 from wazimap_ng.general.admin import filters
 
 
-
 class CategoryMetricsFilter(filters.CategoryFilter):
     parameter_name = 'subcategory__category__id'
 
+
 @admin.register(models.ProfileKeyMetrics)
 class ProfileKeyMetricsAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
-
     exclude_common_list_display = True
     list_display = (
         "label",
@@ -27,6 +26,12 @@ class ProfileKeyMetricsAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
         "updated",
         "order"
     )
+
+    fieldsets = (
+        ("Profile fields", {
+            "fields": ("profile", "subcategory", "label", "variable", "subindicator", "denominator")
+        }),
+    )
     form = ProfileKeyMetricsForm
 
     list_filter = (
@@ -37,15 +42,17 @@ class ProfileKeyMetricsAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
 
     help_texts = ["denominator", ]
 
-    fields = ["profile", "variable", "subindicator", "subcategory", "denominator", "label"]
-    search_fields = ("label", )
+    search_fields = ("label",)
 
+    def get_readonly_fields(self, request, obj=None):
+        if obj:  # editing an existing object
+            return ("profile",) + self.readonly_fields
+        return self.readonly_fields
 
     class Media:
         js = (
             "/static/js/variable_subindicators.js",
         )
-
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)
@@ -58,7 +65,7 @@ class ProfileKeyMetricsAdmin(SortableAdminMixin, BaseAdminModel, HistoryAdmin):
                 category__profile_id=profile_id
             )
         elif not obj and request.method == "GET":
-             qs = qs = models.IndicatorSubcategory.objects.none()
+            qs = qs = models.IndicatorSubcategory.objects.none()
 
         form.base_fields["subcategory"].queryset = qs
 

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -73,7 +73,7 @@ class IndicatorSubcategory(BaseModel, SimpleHistory):
 
 class ProfileKeyMetrics(BaseModel, SimpleHistory):
     profile = models.ForeignKey(Profile, on_delete=models.CASCADE,
-                                help_text="The profile to which this profile indicator belongs")
+                                help_text="The profile to which this key metric belongs")
     variable = models.ForeignKey(Indicator, on_delete=models.CASCADE, )
     subcategory = models.ForeignKey(IndicatorSubcategory, on_delete=models.CASCADE)
     # TODO using an integer here is brittle. The order of the subindicators may change. Should rather use the final value.
@@ -97,15 +97,15 @@ class ProfileKeyMetrics(BaseModel, SimpleHistory):
 
 class ProfileHighlight(BaseModel, SimpleHistory):
     profile = models.ForeignKey(Profile, on_delete=models.CASCADE,
-                                help_text="The profile to which this profile indicator belongs")
+                                help_text="The profile to which this profile highlight belongs")
     indicator = models.ForeignKey(Indicator, on_delete=models.CASCADE,
-                                  help_text="Indicator on which this highlight is based on.", verbose_name="variable")
+                                  help_text="The variable on which this highlight is based on.", verbose_name="variable")
     # TODO using an integer here is brittle. The order of the subindicators may change. Should rather use the final value.
     subindicator = models.PositiveSmallIntegerField(null=True, blank=True)
     denominator = models.CharField(choices=DENOMINATOR_CHOICES, max_length=32,
                                    help_text="Method for calculating the denominator that will normalise this value.")
     label = models.CharField(max_length=255, null=False, blank=True,
-                             help_text="Label for the indicator displayed on the front-end")
+                             help_text="Label for the profile highlight displayed on the front-end")
     order = models.PositiveIntegerField(default=0, blank=False, null=False)
 
     def __str__(self):

--- a/wazimap_ng/profile/models.py
+++ b/wazimap_ng/profile/models.py
@@ -72,7 +72,8 @@ class IndicatorSubcategory(BaseModel, SimpleHistory):
 
 
 class ProfileKeyMetrics(BaseModel, SimpleHistory):
-    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE,
+                                help_text="The profile to which this profile indicator belongs")
     variable = models.ForeignKey(Indicator, on_delete=models.CASCADE, )
     subcategory = models.ForeignKey(IndicatorSubcategory, on_delete=models.CASCADE)
     # TODO using an integer here is brittle. The order of the subindicators may change. Should rather use the final value.
@@ -95,7 +96,8 @@ class ProfileKeyMetrics(BaseModel, SimpleHistory):
 
 
 class ProfileHighlight(BaseModel, SimpleHistory):
-    profile = models.ForeignKey(Profile, on_delete=models.CASCADE)
+    profile = models.ForeignKey(Profile, on_delete=models.CASCADE,
+                                help_text="The profile to which this profile indicator belongs")
     indicator = models.ForeignKey(Indicator, on_delete=models.CASCADE,
                                   help_text="Indicator on which this highlight is based on.", verbose_name="variable")
     # TODO using an integer here is brittle. The order of the subindicators may change. Should rather use the final value.


### PR DESCRIPTION
## Description
Making UI changes in profile highlight & profile key metrics 

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-348

## How to test it locally
* use https://wazimap-pr-417.herokuapp.com/admin/ to test this PR
* go to profile highlights page
* confirm that there are no section headings other than `Profile fields` and `Change reason`
* confirm that the fields are ordered correctly
   - Profile
   - Subcategory
   - Label
   - Variable stuff
 * confirm that helptext is added for Profile selection
 * confirm that once it is saved, Profile is readonly
 * repeat these for profile key metrics page

![image](https://user-images.githubusercontent.com/53019884/182873321-af2e8861-32ac-4026-b48d-8687a630e1b5.png)

![image](https://user-images.githubusercontent.com/53019884/182873690-40749e8d-bebd-4fd6-90a9-27f95b99a30c.png)


## Changelog

### Added

### Updated
* `wazimap_ng/profile/models.py` to add help texts
* `wazimap_ng/profile/admin/admins/profile_highlight_admin.py` & `wazimap_ng/profile/admin/admins/profile_key_metrics_admin.py` to make UI changes

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
