### PR TITLE
Updated summary api to include order and name

### DIFF
--- a/tests/general/views/test_consolidated_profile_view.py
+++ b/tests/general/views/test_consolidated_profile_view.py
@@ -1127,10 +1127,10 @@ class TestProfileGeoSummaryView(ConsolidatedProfileViewBase):
 
         assert len(response.data) == 1
         assert self.get_next_item(response.data) == "category for gender"
-        assert self.get_next_item(response.data["category for gender"]) == "subcategories"
+        assert list(response.data["category for gender"].keys()) == ["order", "name", "subcategories"]
         subcategories = response.data["category for gender"]["subcategories"]
         assert self.get_next_item(subcategories) == "subcategory for gender"
-        assert self.get_next_item(subcategories["subcategory for gender"])== "indicators"
+        assert list(subcategories["subcategory for gender"].keys()) == ["order", "name", "indicators"]
         indicators = subcategories["subcategory for gender"]["indicators"]
         assert len(indicators) == 1
         assert self.get_next_item(indicators) == profile_indicator.label

--- a/wazimap_ng/profile/serializers/indicator_data_summary_serializer.py
+++ b/wazimap_ng/profile/serializers/indicator_data_summary_serializer.py
@@ -31,13 +31,27 @@ def IndicatorDataSummarySerializer(profile, geography, version):
     d_metadata = metadata_serializer(
         children_indicator_data, dataset_groups_dict
     )
+
+    c = qsdict(subcategories,
+        lambda x: x.category.name,
+        lambda x: {
+            "order": x.category.order,
+            "name": x.category.name
+        }
+    )
+
     s = qsdict(subcategories,
-               lambda x: x.category.name,
-               lambda x: "subcategories",
-               "name",
-               )
+        lambda x: x.category.name,
+        lambda x: "subcategories",
+        "name",
+        lambda x: {
+            "order": x.order,
+            "name": x.name
+        }
+    )
 
     new_dict = {}
+    mergedict(new_dict, c)
     mergedict(new_dict, s)
     mergedict(new_dict, d_metadata)
     return new_dict

--- a/wazimap_ng/profile/serializers/utils.py
+++ b/wazimap_ng/profile/serializers/utils.py
@@ -43,7 +43,8 @@ def get_indicator_data(profile, indicators, geographies, version):
                 content_type=F("indicator__profileindicator__content_type"),
                 chart_type=F("indicator__profileindicator__chart_type"),
                 choropleth_range=F("indicator__profileindicator__choropleth_range"),
-                enable_linear_scrubber=F("indicator__profileindicator__enable_linear_scrubber")
+                enable_linear_scrubber=F("indicator__profileindicator__enable_linear_scrubber"),
+                pi_order=F("indicator__profileindicator__order")
             )
             .order_by("indicator__profileindicator__order")
             )
@@ -82,6 +83,8 @@ def metadata_serializer(obj, dataset_groups_dict):
          "profile_indicator_label",
          lambda x: {
              "id": x["profile_indicator_id"],
+             "order": x["pi_order"],
+             "label": x["profile_indicator_label"],
              "description": x["description"],
              "choropleth_method": x["choropleth_method"],
              "last_updated_at": x["last_updated_at"],

--- a/wazimap_ng/profile/serializers/utils.py
+++ b/wazimap_ng/profile/serializers/utils.py
@@ -44,7 +44,7 @@ def get_indicator_data(profile, indicators, geographies, version):
                 chart_type=F("indicator__profileindicator__chart_type"),
                 choropleth_range=F("indicator__profileindicator__choropleth_range"),
                 enable_linear_scrubber=F("indicator__profileindicator__enable_linear_scrubber"),
-                pi_order=F("indicator__profileindicator__order")
+                profile_indicator_order=F("indicator__profileindicator__order")
             )
             .order_by("indicator__profileindicator__order")
             )
@@ -83,7 +83,7 @@ def metadata_serializer(obj, dataset_groups_dict):
          "profile_indicator_label",
          lambda x: {
              "id": x["profile_indicator_id"],
-             "order": x["pi_order"],
+             "order": x["profile_indicator_order"],
              "label": x["profile_indicator_label"],
              "description": x["description"],
              "choropleth_method": x["choropleth_method"],


### PR DESCRIPTION
## Description
Updated summary api with orders of subcategory, category and profile indicator


## Related Issue
https://wazimap.atlassian.net/browse/WNCM-277

## How to test it locally
Request summary api endpoint and it should show order and name as new keys for every subcategory, category and profile indicator

## Changelog


### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
