### PR TITLE
added order property for category and subcategory

### DIFF
--- a/tests/profile/serializers/test_indicator_data_serializer_without_children.py
+++ b/tests/profile/serializers/test_indicator_data_serializer_without_children.py
@@ -75,6 +75,7 @@ class TestIndicatorSerializerWithoutChildren:
         assert pi_data["id"] == profile_indicator.id
         assert pi_data["dataset_content_type"] == "quantitative"
 
+
 @pytest.mark.django_db
 @pytest.mark.usefixtures("qualitative_groups")
 class TestQualitativeData:
@@ -83,7 +84,8 @@ class TestQualitativeData:
     def test_with_qualitative_data(self, profile, geography, version, qualitative_profile_indicator):
         serializer = IndicatorDataSerializerWithoutChildren(profile, geography, version)
         subcategory = qualitative_profile_indicator.subcategory
-        pi_data = serializer[subcategory.category.name]["subcategories"][subcategory.name]["indicators"][qualitative_profile_indicator.label]
+        pi_data = serializer[subcategory.category.name]["subcategories"][subcategory.name]["indicators"][
+            qualitative_profile_indicator.label]
         assert pi_data["dataset_content_type"] == "qualitative"
         assert pi_data["data"] == [{'content': 'This is example text'}, {'content': 'www.test.com'}]
 
@@ -91,7 +93,7 @@ class TestQualitativeData:
 @pytest.mark.django_db
 class TestExtendedProfileSerializer:
     def test_basic_serializer(
-        self, profile, profile_indicator, groups, indicatordata_json
+            self, profile, profile_indicator, groups, indicatordata_json
     ):
         version = profile.geography_hierarchy.root_geography.geographyboundary_set.get().version
         indicator = profile_indicator.indicator
@@ -117,12 +119,15 @@ class TestExtendedProfileSerializer:
         subcategory_name = profile_indicator.subcategory.name
         assert category_name in profile_data
         assert "subcategories" in profile_data[category_name]
+        assert "order" in profile_data[category_name]
         assert subcategory_name in profile_data[category_name]["subcategories"]
         assert "indicators" in profile_data[category_name]["subcategories"][subcategory_name]
+        assert "order" in profile_data[category_name]["subcategories"][subcategory_name]
         indicator_data = profile_data[category_name]["subcategories"][subcategory_name]["indicators"]
         assert "child_data" not in indicator_data[profile_indicator.label]
         assert "data" in indicator_data[profile_indicator.label]
         assert indicator_data[profile_indicator.label]["data"] == indicatordata_json
+        assert "order" in indicator_data[profile_indicator.label]
 
         # assert highlight
         assert "highlights" in data

--- a/wazimap_ng/profile/serializers/indicator_data_serializer_without_children.py
+++ b/wazimap_ng/profile/serializers/indicator_data_serializer_without_children.py
@@ -25,16 +25,17 @@ def IndicatorDataSerializerWithoutChildren(profile, geography, version):
 
     c = qsdict(subcategories,
                lambda x: x.category.name,
-               lambda x: {"description": x.category.description}
+               lambda x: {"description": x.category.description,
+                          "order": x.category.order}
                )
 
     s = qsdict(subcategories,
                lambda x: x.category.name,
                lambda x: "subcategories",
                "name",
-               lambda x: {"description": x.description}
+               lambda x: {"description": x.description,
+                          "order": x.order}
                )
-
 
     d4 = qsdict(indicator_data,
                 "category",


### PR DESCRIPTION
## Description
passing the order property for category and subcategory

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-510

## How to test it locally
Request all details api endpoint and it should show order and name as new keys for every subcategory and category 

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [ ]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
