### PR TITLE
Fixed bug in profile indicator admin initial save

### DIFF
--- a/test_selenium/profile/admin/test_profile_indicator_admin.py
+++ b/test_selenium/profile/admin/test_profile_indicator_admin.py
@@ -104,9 +104,34 @@ class TestProfileIndicatorAdmin(BaseTestCase):
         assert linear_scrubber_checkbox.is_selected() == False
         assert linear_scrubber_checkbox.is_enabled() == False
 
-        variable_field.select_by_value(str(self.indicator2.id))
+        variable_field.select_by_value(str(self.indicator4.id))
         assert linear_scrubber_checkbox.is_enabled() == True
         linear_scrubber_checkbox.click()
         href = "/".join(link_to_group.get_attribute("href").split("/")[3:])
         # Check if link in warning alert also works for private variables
-        assert href == f"admin/datasets/group/{self.group2.id}/change/"
+        assert href == f"admin/datasets/group/{self.group4.id}/change/"
+
+        # Save and continue and check if setting is saved
+        subcategory_element = main_div.find_element(by=By.CSS_SELECTOR, value="select#id_subcategory")
+        subcategory_field = Select(subcategory_element)
+        subcategory_field.select_by_value(str(self.indicator_subcategory.id))
+
+        choropleth_method_element = main_div.find_element(by=By.CSS_SELECTOR, value="select#id_choropleth_method")
+        choropleth_method_field = Select(choropleth_method_element)
+        choropleth_method_field.select_by_value("1")
+
+        main_div.find_element_by_css_selector(
+            ".submit-row input[value='Save and continue editing']"
+        ).click()
+
+        WebDriverWait(self.selenium, 10).until(
+            EC.visibility_of_element_located((By.TAG_NAME, "h1"))
+        )
+
+        main_div = self.get_element("content")
+        header_text = main_div.find_element(by=By.TAG_NAME, value="h1").text
+        assert header_text == "Change profile indicator"
+        linear_scrubber_checkbox = self.get_element("id_enable_linear_scrubber")
+
+        assert linear_scrubber_checkbox.is_selected() == True
+        assert linear_scrubber_checkbox.is_enabled() == True

--- a/test_selenium/profile/admin/test_profile_indicator_admin.py
+++ b/test_selenium/profile/admin/test_profile_indicator_admin.py
@@ -118,7 +118,7 @@ class TestProfileIndicatorAdmin(BaseTestCase):
 
         choropleth_method_element = main_div.find_element(by=By.CSS_SELECTOR, value="select#id_choropleth_method")
         choropleth_method_field = Select(choropleth_method_element)
-        choropleth_method_field.select_by_value("1")
+        choropleth_method_field.select_by_value(str(self.choropleth_method.id))
 
         main_div.find_element_by_css_selector(
             ".submit-row input[value='Save and continue editing']"

--- a/test_selenium/profile/admin/test_profile_indicator_admin.py
+++ b/test_selenium/profile/admin/test_profile_indicator_admin.py
@@ -124,14 +124,8 @@ class TestProfileIndicatorAdmin(BaseTestCase):
             ".submit-row input[value='Save and continue editing']"
         ).click()
 
-        WebDriverWait(self.selenium, 10).until(
-            EC.visibility_of_element_located((By.TAG_NAME, "h1"))
-        )
+        self.wait_until("h1", "Change profile indicator")
 
-        main_div = self.get_element("content")
-        header_text = main_div.find_element(by=By.TAG_NAME, value="h1").text
-        assert header_text == "Change profile indicator"
         linear_scrubber_checkbox = self.get_element("id_enable_linear_scrubber")
-
         assert linear_scrubber_checkbox.is_selected() == True
         assert linear_scrubber_checkbox.is_enabled() == True

--- a/test_selenium/test_base.py
+++ b/test_selenium/test_base.py
@@ -16,13 +16,17 @@ from selenium.common.exceptions import TimeoutException
 from selenium.webdriver.common.keys import Keys
 
 from django.contrib.auth.models import User
-from tests.profile.factories import ProfileFactory
+from tests.profile.factories import (
+    ProfileFactory,
+    IndicatorSubcategoryFactory,
+    IndicatorCategoryFactory
+)
 from tests.datasets.factories import (
     GeographyHierarchyFactory,
     VersionFactory,
     DatasetFactory,
     IndicatorFactory,
-    GroupFactory,
+    GroupFactory
 )
 
 
@@ -109,6 +113,10 @@ class BaseTestCase(LiveServerTestCase):
         self.dataset4 = DatasetFactory(name="dataset4", profile=self.public_profile2, permission_type="private")
         self.indicator4 = IndicatorFactory(name="indicator4", dataset=self.dataset4)
         self.group4 = GroupFactory(name=self.indicator4.groups[0], dataset=self.dataset4)
+
+        # Indicator category and subcategory
+        self.indicator_category = IndicatorCategoryFactory(name="public_profile", profile=self.public_profile2)
+        self.indicator_subcategory = IndicatorSubcategoryFactory(name="public_profile2", category=self.indicator_category)
 
         # Create superuser
         self.user_password = "mypassword"

--- a/test_selenium/test_base.py
+++ b/test_selenium/test_base.py
@@ -19,7 +19,8 @@ from django.contrib.auth.models import User
 from tests.profile.factories import (
     ProfileFactory,
     IndicatorSubcategoryFactory,
-    IndicatorCategoryFactory
+    IndicatorCategoryFactory,
+    ChoroplethMethodFactory
 )
 from tests.datasets.factories import (
     GeographyHierarchyFactory,
@@ -127,6 +128,9 @@ class BaseTestCase(LiveServerTestCase):
         self.superuser.is_superuser = True
         self.superuser.is_staff = True
         self.superuser.save()
+
+        # Choropleth Method
+        self.choropleth_method = ChoroplethMethodFactory(name="test")
 
     def get_url(self, path):
         return f"{self.live_server_url}{path}"

--- a/test_selenium/test_base.py
+++ b/test_selenium/test_base.py
@@ -169,6 +169,15 @@ class BaseTestCase(LiveServerTestCase):
         ).text
         assert site_header_text == self.site_header_text
 
+    def wait_until(self, tag_name, text):
+        WebDriverWait(self.selenium, 10).until(
+            EC.visibility_of_element_located((By.TAG_NAME, tag_name))
+        )
+
+        main_div = self.get_element("content")
+        header_text = main_div.find_element(by=By.TAG_NAME, value=tag_name).text
+        assert header_text == text
+
     @classmethod
     def tearDownClass(cls):
         cls.selenium.quit()

--- a/wazimap_ng/profile/admin/forms/profile_indicator_form.py
+++ b/wazimap_ng/profile/admin/forms/profile_indicator_form.py
@@ -43,5 +43,3 @@ class ProfileIndicatorAdminForm(HistoryAdminForm):
         if self.instance.id:
             profile_id = self.instance.profile_id
             self.fields['indicator'].queryset = filter_indicators_by_profile(profile_id)
-        else:
-            self.fields['enable_linear_scrubber'].disabled = True


### PR DESCRIPTION
## Description
It was due to attribute disabled set in __init__ of form.

## Related Issue
https://wazimap.atlassian.net/browse/WNCM-509

## How to test it locally
Go to profile indicator admin.
Save new profile indicator with enable linear scrubber option checked
After save linear scrubber option should be checked

## Changelog

### Added

### Updated

### Removed


## Checklist

- [x]  🚀 is the code ready to be merged and go live?
- [x]  🛠 does it work (build) locally

### Pull Request

- [x]  📰 good title
- [x]  📝good description
- [x]  🔖 issue linked
- [x]  📖 changelog filled out

### Commits

- [x]  commits are clean
- [x]  commit messages are clean

### Code Quality

- [x]  🚧 no commented out code
- [x]  🖨 no unnecessary logging
- [x]  🎱 no magic numbers
- [x]  black was run locally (as part of the pre-commit hook)

### Testing

- [x]  ✅ added (appropriate) unit tests
- [x]  💢 edge cases in tests were considered
- [x]  ✅ ran tests locally & are passing
