### PR TITLE
Added GUNICORN_TIMEOUT env variable to allow for configurable timeouts

### DIFF
--- a/scripts/django/web.sh
+++ b/scripts/django/web.sh
@@ -2,4 +2,4 @@
 
 cd /app
 
-/usr/local/bin/gunicorn wazimap_ng.wsgi --workers=2 -b 0.0.0.0:${PORT:-8000} --forwarded-allow-ips="*"  --reload  --timeout=300
+/usr/local/bin/gunicorn wazimap_ng.wsgi --workers=2 -b 0.0.0.0:${PORT:-8000} --forwarded-allow-ips="*"  --reload  --timeout=${GUNICORN_TIMEOUT:-300}


### PR DESCRIPTION
## Description

Some of the API requests are taking longer than the 300 second timeout currently configured and so they time out. Until we can shift those API requests to background tasks and better caching we can temporarily increase the timeout. This change adds a `GUNICORN_TIMEOUT` environment variable defaulting to `300`.

## How to test it locally

Only works in production by default. In dev/local you could try and run the Gunicorn server with the `GUNICORN_TIMEOUT` variable set.